### PR TITLE
Generate a Kickstart file that can be used with the Yum-based SPMA

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -877,7 +877,7 @@ sub yum_install_packages
 
     my @pkgs;
     my $t = $config->getElement (PKG)->getTree();
-    my %base = map($_ => 1, @{$config->getElement (BASE_PKGS)->getTree()});
+    my %base = map(($_ => 1), @{$config->getElement (BASE_PKGS)->getTree()});
 
     print <<EOF;
 # This one will be reinstalled by Yum in the correct version for our


### PR DESCRIPTION
The Yum-based SPMA obsoletes part of the old installation procedure.

This branch:
- Sets up the Yum repositories in a temporary location, 
- Installs the basic RPMs during the `%post` phase.
- Removes the zillion `rpm -i` statements.
- Keeps the execution of ncm-spma in the `post_reboot` scriptlet.

Overall, I feel installations are slighlty faster than they used to be.
