### PR TITLE
Ignore repositories unavailable at installation

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -549,9 +549,8 @@ sub ksinstall_rpm
 {
     my ($config, @pkgs) = @_;
 
-    print "# Weird error handling because Yum's sucks\n",
-	"yum -c /tmp/aii/yum/yum.conf -y install ", join("\\\n    ", @pkgs),
-	"2>&1 |&& fail 'Unable to install packages'\n";
+    print "yum -c /tmp/aii/yum/yum.conf -y install ", join("\\\n    ", @pkgs),
+	 "|| fail 'Unable to install packages'\n";
 }
 
 sub proxy


### PR DESCRIPTION
We only need the repositories that contain some public RPMs.  Other repositories that cannot be accessed now may be accessed later when SPMA is properly executed.
