### PR TITLE
Fix bug in MTU declaration.

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -151,7 +151,8 @@ sub ksnetwork
 	    return;
     }
 
-    print "--mtu=$net->{mtu} " if exists($net->{mtu});
+    my $mtu = exists($net->{mtu}) ? "--mtu=$net->{mtu} " : "";
+
     my $gw = '--gateway=';
     if (exists($net->{gateway})) {
         $gw .= $net->{gateway};
@@ -173,7 +174,7 @@ EOF
 
     my $ns = $config->getElement(NAMESERVER)->getValue;
     print <<EOF;
-network --bootproto=static --ip=$net->{ip} --netmask=$net->{netmask} $gw --nameserver=$ns --device=$dev --hostname=$fqdn
+network --bootproto=static --ip=$net->{ip} --netmask=$net->{netmask} $gw --nameserver=$ns --device=$dev --hostname=$fqdn $mtu
 EOF
 
 }


### PR DESCRIPTION
According to Andrea, it was printing a network line that looked like this:

```
--mtu=9000 network --bootproto=static --ip=131.154.192.11
--netmask=255.255.252.0 --gateway=131.154.192.1
--nameserver=131.154.128.2 --device=eth0
--hostname=wn-test.cr.cnaf.infn.it
```

We now print the mtu field at the end of the line!
