### PR TITLE
Ignore repositories unavailable at installation

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -550,7 +550,7 @@ sub ksinstall_rpm
     my ($config, @pkgs) = @_;
 
     print "yum -c /tmp/aii/yum/yum.conf -y install ", join("\\\n    ", @pkgs),
-	" || fail 'Unable to install packages'\n";
+	 "|| fail 'Unable to install packages'\n";
 }
 
 sub proxy
@@ -849,6 +849,7 @@ enabled=1
 baseurl=$repo->{protocols}->[0]->{url}
 name=$repo->{name}
 gpgcheck=0
+skip_if_unavailable=1
 EOF
 	if ($ptype && $ptype eq 'forward') {
 	    print <<EOF;


### PR DESCRIPTION
In most cases they will become available after SPMA runs and Yum is completely configured.
