### PR TITLE
Display why the profiles-info fails to download.

### DIFF
--- a/aii-core/src/main/perl/aii-shellfe
+++ b/aii-core/src/main/perl/aii-shellfe
@@ -876,7 +876,8 @@ sub nodelist
         $self->debug (4, "Downloading profiles-info: $url");
         my $rp = $ua->get ($url);
         unless ($rp->is_success) {
-                $self->error ("Couldn't download $url. Aborting");
+                $self->error ("Couldn't download $url. Aborting ",
+                              $rp->status_line());
                 $self->{state} = 1;
                 return;
         }


### PR DESCRIPTION
It's terribly annoying to see an "unable to download profiles-info" with no explanations at all.  This fixes it.

The first commit is just whitespace fixes for making the second commit easier to read.
