### PR TITLE
Remove references to LAPP repositories.

### DIFF
--- a/aii-core/pom.xml
+++ b/aii-core/pom.xml
@@ -77,13 +77,6 @@
     </build-info>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://lapp-repo01.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <profiles>
 
     <profile>

--- a/aii-dhcp/pom.xml
+++ b/aii-dhcp/pom.xml
@@ -78,13 +78,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://lapp-repo01.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <build>
     <pluginManagement>
       <plugins>

--- a/aii-ks/pom.xml
+++ b/aii-ks/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.29</version>
+    <version>1.31</version>
   </parent>
 
   <developers>
@@ -78,13 +78,6 @@
       <classifier>scripts</classifier>
     </dependency>
   </dependencies>
-
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://lapp-repo01.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
 
   <build>
     <pluginManagement>

--- a/aii-pxelinux/pom.xml
+++ b/aii-pxelinux/pom.xml
@@ -78,13 +78,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://lapp-repo01.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
These repositories are dead, and block any builds on new systems.
