### PR TITLE
Add quattor-installer command symlink

### DIFF
--- a/aii-core/pom.xml
+++ b/aii-core/pom.xml
@@ -257,6 +257,10 @@
                       <exclude>*.pod</exclude>
                     </excludes>
                   </source>
+                  <softlinkSource>
+                    <destination>quattor-installer</destination>
+                    <location>aii-shellfe</location>
+                  </softlinkSource>
                 </sources>
               </mapping>
 


### PR DESCRIPTION
Based on TCD's quattor_commands.tpl to begin the implementation of
https://trac.lal.in2p3.fr/Quattor/wiki/Development/Scrum/CommandRenaming

Includes a commit to replace the tabs in pom.xml with spaces.
