### PR TITLE
Wait until the network is before running the post-reboot script

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -644,6 +644,18 @@ exec &> /root/ks-post-install.log
 tail -f /root/ks-post-install.log &>/dev/console &
 set -x
 
+# Wait up to 2 minutes until the network comes up
+i=0
+while ! nslookup \\`hostname\\` > /dev/null
+do
+    sleep 1
+    let i = \\\$i+1
+    if [ \\\$i -gt 120 ]
+    then
+       fail "Network does not come up"
+    fi
+done
+
 EOF
 }
 


### PR DESCRIPTION
On SL 6.4 the `ks-post-reboot` script may start before the network is actually working, causing all sorts of crashes.

We wait up to 2 minutes for it to show up now.
