### PR TITLE
Fix syntax error in waiting loop for network

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -740,7 +740,7 @@ i=0
 while ! nslookup \\`hostname\\` > /dev/null
 do
     sleep 1
-    let i = \\\$i+1
+    let i=\\\$i+1
     if [ \\\$i -gt 120 ]
     then
        fail "Network does not come up"


### PR DESCRIPTION
Fix syntax error in a change introduced in previous version to wait for the network
