### PR TITLE
Extend the validation regexp for bootif

### DIFF
--- a/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
+++ b/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
@@ -8,7 +8,7 @@ unique template quattor/aii/pxelinux/schema;
 type structure_pxelinux_pxe_info = {
 	"initrd"	: string
 	"kernel"	: string
-	"ksdevice"	: string with match (SELF, ("^(eth[0-9]+|link|fd|bootif)$")) || is_hwaddr (SELF)
+	"ksdevice"	: string with match (SELF, ("^(eth[0-9]+|link|p[0-9]+p[0-9]+|fd|em[0-9]+|bootif)$")) || is_hwaddr (SELF)
 	"kslocation"	: type_absoluteURI
 	"label"		: string
 	"append"	? string


### PR DESCRIPTION
Backport fix from master branch...
It has to accommodate pXpY and emZ namings.

BTW, pxelinux modified schema doesn't seem to appear in target/pan. A pom.xml issue?
