### PR TITLE
Make wipe_metadata more reliable

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -697,25 +697,25 @@ end_of_fdisk
 }
 
 wipe_metadata () {
-    local path clear SIZE START
+    local path clear SIZE ENDSEEK ENDSEEK_OFFSET
     path="$1"
-    #give an initial value
-    SIZE=0
-    #try get the size with fdisk
+	ENDSEEK_OFFSET=20
+    # try to get the size with fdisk
     SIZE=`fdisk -lu "$path" |grep total|grep sectors|awk -F ' ' '{print $8}'`
-    #if zero assume we failed and try with parted
+    # if empty, assume we failed and try with parted
     if [ -z $SIZE ]; then
         SIZE=`parted "$path" -s -- u s p | grep "Disk $path" |awk '{print substr($3, 0, length($3)-1)}'`
-        #if at this point the SIZE has not been determined, set it to 20, so the entire disk gets wiped. Bad, but better than spitting confusing errors
+        # if at this point the SIZE has not been determined, 
+        # set it equal to ENDSEEK_OFFSET, the entire disk gets wiped. 
         if [ -z $SIZE ]; then
-        SIZE=20
-        echo "[WARN] I could not determine the size of device $path with both fdisk and parted. Wiping whole drive instead"
+            SIZE=$ENDSEEK_OFFSET
+            echo "[WARN] Could not determine the size of device $path with both fdisk and parted. Wiping whole drive instead"
         fi
     fi
-    let START=$SIZE-20
-    echo "INFO: wipe path $path with SIZE $SIZE and START $START"
+    let ENDSEEK=$SIZE-$ENDSEEK_OFFSET
+    echo "[INFO] wipe path $path with SIZE $SIZE and ENDSEEK $ENDSEEK"
     dd if=/dev/zero of="$path" bs=512 count=10 2>/dev/null
-    dd if=/dev/zero of="$path" bs=512 seek=$START 2>/dev/null
+    dd if=/dev/zero of="$path" bs=512 seek=$ENDSEEK 2>/dev/null
 }
 
 EOF


### PR DESCRIPTION
Get the size of the drive in logical sectors (512 bytes), then wipe the first 10 and last 20 sectors.

We have to use fdisk because parted in SL5 will refuse to display the size of an unlabeled drive. However parted support has been added as a fallback if fdisk fails.

If size cannot be determined by any means then the entire drive gets wiped, as it happened before. This change also prints a message when that happens so that the user is aware - instead of guessing.

The first 10 and last 20 sectors were chosen after reading http://kezhong.wordpress.com/2011/06/14/how-to-remove-bios-raid-metadata-from-disk-on-fedora/. They have been tested with RAL diskservers. They should be enough to wipe gpt partition information and raid metadata.

Discussion has taken place in the old pull request https://github.com/quattor/aii/pull/61, which was closed because of messed up commit history.
