### PR TITLE
Get the certificate from freeIPA

### DIFF
--- a/aii-freeipa/src/main/pan/quattor/aii/freeipa/schema.pan
+++ b/aii-freeipa/src/main/pan/quattor/aii/freeipa/schema.pan
@@ -66,7 +66,6 @@ type structure_aii_freeipa = {
 
     "dns" : boolean = false # DNS is controlled by FreeIPA (to register the host ip)
     "disable" : boolean = true # disable the host on AII removal
-
-     "extract_x509" : boolean = false # if true, will extract cert, key and ca files from nssdb
+    "extract_x509" : boolean = false # if true, will extract cert, key and ca files from nssdb
 };
 

--- a/aii-freeipa/src/main/perl/freeipa.pm
+++ b/aii-freeipa/src/main/perl/freeipa.pm
@@ -116,9 +116,8 @@ EOF
 
     #Extract cert, key and ca files from nssdb if use_nss.
     if ( $tree->{extract_x509} ) {
-        $self->extract_x509($config,$hostname,$domainname);
+        $self->extract_x509($config, $hostname, $domainname);
     }
-
 
 }
 
@@ -127,7 +126,7 @@ EOF
 #
 sub extract_x509 
 {
-    my ($self, $config,$hostname,$domainname) = @_;
+    my ($self, $config, $hostname, $domainname) = @_;
     my $ccm = $config->getElement('/software/components/ccm')->getTree;
     my $ccm_cert_file = $ccm->{cert_file};
     my $ccm_key_file = $ccm->{key_file};


### PR DESCRIPTION
These commands extracts the host certificate and key and the IPA CA certificate from nssdb. This is required when using ccm-fetch over SSL with a non-kerberos apache webserver. 
