### PR TITLE
Fix wrong regex check on installtype when using a proxy

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -361,7 +361,7 @@ sub kscommands
     push(@packages, 'bind-utils'); # required for nslookup usage in ks-post-install
     
     my $installtype = $tree->{installtype};
-    if ($installtype =~ /^http/) {
+    if ($installtype =~ /http/) {
         my ($proxyhost, $proxyport, $proxytype) = proxy($config);
         if ($proxyhost) {
             if ($proxyport) {


### PR DESCRIPTION
After upgrading from 14.2.1 to 14.8.0, the proxy was not correctly defined on the "installtype" line in the ks anymore.
After investigation, the regex condition to handle this has been changed between the 2 versions : the line was requiring to **start with** "http" but it contains "url --url http://...". 
The check should only verify if the line **contains** "http" 
After this change, the proxy is correctly defined now.
