### PR TITLE
aii-opennebula: Include new install hook

### DIFF
--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
@@ -6,6 +6,19 @@ include 'quattor/aii/opennebula/schema';
 variable OPENNEBULA_AII_FORCE ?= undef; 
 variable OPENNEBULA_AII_ONHOLD ?= undef;
 
+"/system/aii/hooks/configure/" = {
+    append(nlist(
+        'module', OPENNEBULA_AII_MODULE_NAME,
+
+        "image", OPENNEBULA_AII_FORCE,
+        "template", OPENNEBULA_AII_FORCE,
+        ));
+
+    SELF;
+};
+
+bind "/system/aii/hooks" = nlist with validate_aii_opennebula_hooks('configure');
+
 "/system/aii/hooks/install/" = {
     append(nlist(
         'module', OPENNEBULA_AII_MODULE_NAME,
@@ -13,7 +26,7 @@ variable OPENNEBULA_AII_ONHOLD ?= undef;
         "image", OPENNEBULA_AII_FORCE,
         "template", OPENNEBULA_AII_FORCE,
         "vm", OPENNEBULA_AII_FORCE,
-        "onhold", OPENNEBULA_AII_ONHOLD
+        "onhold", OPENNEBULA_AII_ONHOLD,
         ));
 
     SELF;

--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
@@ -12,6 +12,7 @@ variable OPENNEBULA_AII_ONHOLD ?= undef;
 
         "image", OPENNEBULA_AII_FORCE,
         "template", OPENNEBULA_AII_FORCE,
+        "stopvm", OPENNEBULA_AII_FORCE,
         ));
 
     SELF;
@@ -23,8 +24,6 @@ bind "/system/aii/hooks" = nlist with validate_aii_opennebula_hooks('configure')
     append(nlist(
         'module', OPENNEBULA_AII_MODULE_NAME,
 
-        "image", OPENNEBULA_AII_FORCE,
-        "template", OPENNEBULA_AII_FORCE,
         "vm", OPENNEBULA_AII_FORCE,
         "onhold", OPENNEBULA_AII_ONHOLD,
         ));

--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
@@ -12,7 +12,6 @@ variable OPENNEBULA_AII_ONHOLD ?= undef;
 
         "image", OPENNEBULA_AII_FORCE,
         "template", OPENNEBULA_AII_FORCE,
-        "stopvm", OPENNEBULA_AII_FORCE,
         ));
 
     SELF;

--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -44,8 +44,7 @@ function validate_aii_opennebula_hooks = {
 type structure_aii_opennebula = {
     "module" : string with SELF == OPENNEBULA_AII_MODULE_NAME
     "image" : boolean = false # force create image [implies on remove remove image (also stop/delete vm) ]
-    "template" : boolean = false # force (re)create template [implies on remove remove template (also stop/delete vm) ]
-    "stopvm" : boolean = true # force stop running VM
+    "template" : boolean = false # force (re)create template [implies on remove template (also stop/delete vm) ]
     "vm" : boolean = false # instantiate template (i.e. make vm)
     "onhold" : boolean = true # when template is instantiated, then vm is placed onhold [if false, will start the VM asap]
     "remove" : boolean = true # remove all VM resources

--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -45,6 +45,7 @@ type structure_aii_opennebula = {
     "module" : string with SELF == OPENNEBULA_AII_MODULE_NAME
     "image" : boolean = false # force create image [implies on remove remove image (also stop/delete vm) ]
     "template" : boolean = false # force (re)create template [implies on remove remove template (also stop/delete vm) ]
+    "stopvm" : boolean = true # force stop running VM
     "vm" : boolean = false # instantiate template (i.e. make vm)
     "onhold" : boolean = true # when template is instantiated, then vm is placed onhold [if false, will start the VM asap]
     "remove" : boolean = true # remove all VM resources

--- a/aii-opennebula/src/main/perl/opennebula.pm
+++ b/aii-opennebula/src/main/perl/opennebula.pm
@@ -462,6 +462,28 @@ sub is_one_resource_available
     return;
 }
 
+# Based on Quattor template this function:
+# creates/updates VM templates
+# creates new VM image for each $harddisks
+sub configure
+{
+    my ($self, $config, $path) = @_;
+    my $tree = $config->getElement($path)->getTree();
+
+    my $createvmtemplate = $tree->{template};
+    $main::this_app->info("Create VM template flag is set to: $createvmtemplate");
+
+    # Set one endpoint RPC connector
+    my $one = make_one();
+    if (!$one) {
+        error("No ONE instance returned");
+        return 0;
+    }
+
+    # Check RPC endpoint and OpenNebula version
+    return 0 if !$self->is_supported_one_version($one);
+
+}
 
 # Based on Quattor template this function:
 # creates new VM templates

--- a/aii-opennebula/src/main/perl/opennebula.pm
+++ b/aii-opennebula/src/main/perl/opennebula.pm
@@ -463,6 +463,7 @@ sub is_one_resource_available
 }
 
 # Based on Quattor template this function:
+# Stop running VM if necessary
 # creates/updates VM templates
 # creates new VM image for each $harddisks
 # creates new vnet ars if required
@@ -472,8 +473,6 @@ sub configure
     my $tree = $config->getElement($path)->getTree();
     my $forcecreateimage = $tree->{image};
     $main::this_app->info("Forcecreate image flag is set to: $forcecreateimage");
-    my $stopvm = $tree->{stopvm};
-    $main::this_app->info("Stop running VM flag is set to: $stopvm");
     my $createvmtemplate = $tree->{template};
     $main::this_app->info("Create VM template flag is set to: $createvmtemplate");
 
@@ -489,7 +488,9 @@ sub configure
     # Check RPC endpoint and OpenNebula version
     return 0 if !$self->is_supported_one_version($one);
 
-    $self->stop_and_remove_one_vms($one, $fqdn) if $stopvm;
+    if ($forcecreateimage || $createvmtemplate) {
+        $self->stop_and_remove_one_vms($one, $fqdn);
+    }
 
     my %images = $self->get_images($config);
     $self->remove_and_create_vm_images($one, $forcecreateimage, \%images);

--- a/aii-opennebula/src/main/perl/opennebula.pod
+++ b/aii-opennebula/src/main/perl/opennebula.pod
@@ -52,6 +52,10 @@ Create VM images. Note: if this hook is set the current VM images will be overwr
 
 Create VM template
 
+=item * stopvm : boolean
+
+Stop current running VM
+
 =back
 
 =head3 install
@@ -60,17 +64,9 @@ The next paths are relative to /system/aii/hooks/install
 
 =over 4
 
-=item * image : boolean
-
-Create VM images. Note: if this hook is set the current VM images will be overwritten
-
 =item * vm : boolean
 
 The new VM is instantiated after resources creation
-
-=item * template : boolean
-
-Create VM template
 
 =item * onhold : boolean
 

--- a/aii-opennebula/src/main/perl/opennebula.pod
+++ b/aii-opennebula/src/main/perl/opennebula.pod
@@ -16,7 +16,7 @@ This AII hook generates the required resources and templates to instantiate/crea
 =head2 RESOURCES
 
 
-=head3 install
+=head3 configure
 
 Modify your machine template to:
 
@@ -39,6 +39,22 @@ Modify your machine template to:
 =item * enable acpid service
 
 =back
+
+The next paths are relative to /system/aii/hooks/configure
+
+=over 4
+
+=item * image : boolean
+
+Create VM images. Note: if this hook is set the current VM images will be overwritten
+
+=item * template : boolean
+
+Create VM template
+
+=back
+
+=head3 install
 
 The next paths are relative to /system/aii/hooks/install
 

--- a/aii-opennebula/src/main/perl/opennebula.pod
+++ b/aii-opennebula/src/main/perl/opennebula.pod
@@ -46,15 +46,11 @@ The next paths are relative to /system/aii/hooks/configure
 
 =item * image : boolean
 
-Create VM images. Note: if this hook is set the current VM images will be overwritten
+Create VM images. Note: if this hook is set the current VM images will be overwritten (also stop/delete VM)
 
 =item * template : boolean
 
-Create VM template
-
-=item * stopvm : boolean
-
-Stop current running VM
+Create VM template.
 
 =back
 

--- a/aii-opennebula/src/test/perl/basic.t
+++ b/aii-opennebula/src/test/perl/basic.t
@@ -56,4 +56,17 @@ ok(rpc_history_ok(["one.vmpool.info",
                    "one.template.info",
                    "one.template.instantiate"]),
                    "install rpc history ok");
+
+## test configure
+#rpc_history_reset;
+
+#$path = "/system/aii/hooks/configure/0";
+#$aii->configure($cfg, $path);
+
+##diag_rpc_history;
+#ok(rpc_history_ok(["one.imagepool.info",
+#                   "one.templatepool.info",
+#                   "one.template.allocate",
+#                   "one.template.info"]),
+#                   "install rpc history ok");
 done_testing();

--- a/aii-opennebula/src/test/perl/basic.t
+++ b/aii-opennebula/src/test/perl/basic.t
@@ -35,38 +35,38 @@ rpc_history_reset;
 
 $path = "/system/aii/hooks/remove/0";
 $aii->remove($cfg, $path);
-
 #diag_rpc_history;
 ok(rpc_history_ok(["one.vmpool.info",
                    "one.imagepool.info",
                    "one.templatepool.info"]),
                    "remove rpc history ok");
 
-# test ks install
+# test configure
 rpc_history_reset;
 
-$path = "/system/aii/hooks/install/0";
-$aii->install($cfg, $path);
-
+$path = "/system/aii/hooks/configure/0";
+$aii->configure($cfg, $path);
 #diag_rpc_history;
 ok(rpc_history_ok(["one.vmpool.info",
                    "one.imagepool.info",
                    "one.templatepool.info",
                    "one.template.allocate",
+                   "one.template.info"]),
+                   "configure rpc history ok");
+
+# test ks install
+rpc_history_reset;
+
+$path = "/system/aii/hooks/install/0";
+$aii->install($cfg, $path);
+#diag_rpc_history;
+ok(rpc_history_ok(["one.vmpool.info",
+                   "one.vm.info",
+                   "one.templatepool.info",
                    "one.template.info",
+                   "one.imagepool.info",
+                   "one.image.info",
                    "one.template.instantiate"]),
                    "install rpc history ok");
 
-## test configure
-#rpc_history_reset;
-
-#$path = "/system/aii/hooks/configure/0";
-#$aii->configure($cfg, $path);
-
-##diag_rpc_history;
-#ok(rpc_history_ok(["one.imagepool.info",
-#                   "one.templatepool.info",
-#                   "one.template.allocate",
-#                   "one.template.info"]),
-#                   "install rpc history ok");
 done_testing();

--- a/aii-opennebula/src/test/perl/vmtemplate.t
+++ b/aii-opennebula/src/test/perl/vmtemplate.t
@@ -33,9 +33,7 @@ my $one = $aii->make_one();
 
 # Check VM template creation
 rpc_history_reset;
-diag("HERE IS vmtemplate install history1:");
 $aii->remove_and_create_vm_template($one, $templatename, 1, $vmtemplate);
-diag("HERE IS vmtemplate install history2:");
 #diag_rpc_history;
 ok(rpc_history_ok(["one.templatepool.info",
                    "one.template.info",
@@ -46,9 +44,7 @@ ok(rpc_history_ok(["one.templatepool.info",
 
 # Check VM template update
 rpc_history_reset;
-diag("HERE IS vmtemplate update history1:");
 $aii->remove_and_create_vm_template($one, $templatename, 0, $vmtemplate);
-diag("HERE IS vmtemplate update history2:");
 ok(rpc_history_ok(["one.templatepool.info",
                    "one.template.info",
                    "one.template.update"]),
@@ -56,9 +52,7 @@ ok(rpc_history_ok(["one.templatepool.info",
 
 # Check VM template remove
 rpc_history_reset;
-diag("HERE IS vmtemplate remove history1:");
 $aii->remove_and_create_vm_template($one, $templatename, 1, $vmtemplate, 1);
-diag("HERE IS vmtemplate remove history2:");
 ok(rpc_history_ok(["one.templatepool.info",
                    "one.template.info",
                    "one.template.delete"]),

--- a/aii-opennebula/src/test/perl/vmtemplate.t
+++ b/aii-opennebula/src/test/perl/vmtemplate.t
@@ -33,7 +33,9 @@ my $one = $aii->make_one();
 
 # Check VM template creation
 rpc_history_reset;
+diag("HERE IS vmtemplate install history1:");
 $aii->remove_and_create_vm_template($one, $templatename, 1, $vmtemplate);
+diag("HERE IS vmtemplate install history2:");
 #diag_rpc_history;
 ok(rpc_history_ok(["one.templatepool.info",
                    "one.template.info",
@@ -44,7 +46,9 @@ ok(rpc_history_ok(["one.templatepool.info",
 
 # Check VM template update
 rpc_history_reset;
+diag("HERE IS vmtemplate update history1:");
 $aii->remove_and_create_vm_template($one, $templatename, 0, $vmtemplate);
+diag("HERE IS vmtemplate update history2:");
 ok(rpc_history_ok(["one.templatepool.info",
                    "one.template.info",
                    "one.template.update"]),
@@ -52,7 +56,9 @@ ok(rpc_history_ok(["one.templatepool.info",
 
 # Check VM template remove
 rpc_history_reset;
+diag("HERE IS vmtemplate remove history1:");
 $aii->remove_and_create_vm_template($one, $templatename, 1, $vmtemplate, 1);
+diag("HERE IS vmtemplate remove history2:");
 ok(rpc_history_ok(["one.templatepool.info",
                    "one.template.info",
                    "one.template.delete"]),

--- a/aii-opennebula/src/test/resources/basic.pan
+++ b/aii-opennebula/src/test/resources/basic.pan
@@ -6,7 +6,6 @@ prefix "/system/aii/hooks";
 "configure/0" = nlist(
     "image", true,
     "template", true,
-    "stopvm", true,
 );
 
 "install/0" = nlist(

--- a/aii-opennebula/src/test/resources/basic.pan
+++ b/aii-opennebula/src/test/resources/basic.pan
@@ -3,6 +3,11 @@ object template basic;
 include 'vm';
 
 prefix "/system/aii/hooks";
+"configure/0" = nlist(
+    "image", true,
+    "template", true,
+);
+
 "install/0" = nlist(
     "image", true,
     "vm", true,
@@ -13,5 +18,5 @@ prefix "/system/aii/hooks";
 "remove/0" = nlist(
     "remove", true,
     "image", true,
-    "vmtemplate", true,
+    "template", true,
 );

--- a/aii-opennebula/src/test/resources/basic.pan
+++ b/aii-opennebula/src/test/resources/basic.pan
@@ -6,12 +6,11 @@ prefix "/system/aii/hooks";
 "configure/0" = nlist(
     "image", true,
     "template", true,
+    "stopvm", true,
 );
 
 "install/0" = nlist(
-    "image", true,
     "vm", true,
-    "template", true,
     "onhold", true,
 );
 

--- a/aii-opennebula/src/test/resources/kickstart.pan
+++ b/aii-opennebula/src/test/resources/kickstart.pan
@@ -3,6 +3,11 @@ object template kickstart;
 include 'vm';
 
 prefix "/system/aii/hooks";
+"configure/0" = nlist(
+    "image", true,
+    "template", true,
+);
+
 "install/0" = nlist(
     "image", true,
     "vm", true,
@@ -13,5 +18,5 @@ prefix "/system/aii/hooks";
 "remove/0" = nlist(
     "remove", true,
     "image", true,
-    "vmtemplate", true,
+    "template", true,
 );

--- a/aii-opennebula/src/test/resources/kickstart.pan
+++ b/aii-opennebula/src/test/resources/kickstart.pan
@@ -6,7 +6,6 @@ prefix "/system/aii/hooks";
 "configure/0" = nlist(
     "image", true,
     "template", true,
-    "stopvm", true,
 );
 
 "install/0" = nlist(

--- a/aii-opennebula/src/test/resources/kickstart.pan
+++ b/aii-opennebula/src/test/resources/kickstart.pan
@@ -6,12 +6,11 @@ prefix "/system/aii/hooks";
 "configure/0" = nlist(
     "image", true,
     "template", true,
+    "stopvm", true,
 );
 
 "install/0" = nlist(
-    "image", true,
     "vm", true,
-    "template", true,
     "onhold", true,
 );
 


### PR DESCRIPTION
This PR includes a new configure hook:
 * #107  : Update OpenNebula templates from configure hook 

It was included a new hook to create/update Opennebula templates so now:
 * configure: create/update vm/vnet templates. It also generates new vm images.
 * install: instantiate/stop vm
 * remove: remove images/templates/vm

**NOTE:** This PR requires aii-pxelinux `Configure` hook to work. https://github.com/quattor/aii/pull/114