### PR TITLE
aii-ks: Correct el7 variant from rhel7rc to el7

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/variants/el7.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/variants/el7.pan
@@ -1,6 +1,6 @@
 # Template containing OS configuration and default values.
 
-template quattor/aii/ks/variants/rhel7rc;
+template quattor/aii/ks/variants/el7;
 
 # Remove deprecated options 
 prefix "/system/aii/osinstall/ks";


### PR DESCRIPTION
Matches the template library expectation! Old name `rhel7rc` clearly inappropriate...