### PR TITLE
Support all five systemd device naming schemes

### DIFF
--- a/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
+++ b/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
@@ -8,7 +8,7 @@ unique template quattor/aii/pxelinux/schema;
 type structure_pxelinux_pxe_info = {
     "initrd"	: string
     "kernel"	: string
-    "ksdevice"	: string with match (SELF, ("^(eth[0-9]+|link|p[0-9]+p[0-9]+|fd|em[0-9]+|bootif)$")) || is_hwaddr (SELF)
+    "ksdevice"  : string with match (SELF, ('^(bootif|link|(eth|seth|em|bond|br|vlan|usb|ib|p\d+p|en(o|(p\d+)?s))\d+(\.\d+)?|enx\p{XDigit}{12})$')) || is_hwaddr (SELF)
     "kslocation"	: type_absoluteURI
     "label"		: string
     "append"	? string

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_1.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_1.pan
@@ -1,0 +1,6 @@
+object template pxelinux_ks_ksdevice_systemd_scheme_1;
+
+include 'pxelinux_ks';
+
+prefix "/system/aii/nbp/pxelinux";
+"ksdevice" = "eno1";

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_2.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_2.pan
@@ -1,0 +1,6 @@
+object template pxelinux_ks_ksdevice_systemd_scheme_2;
+
+include 'pxelinux_ks';
+
+prefix "/system/aii/nbp/pxelinux";
+"ksdevice" = "ens1";

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_3.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_3.pan
@@ -1,0 +1,6 @@
+object template pxelinux_ks_ksdevice_systemd_scheme_3;
+
+include 'pxelinux_ks';
+
+prefix "/system/aii/nbp/pxelinux";
+"ksdevice" = "enp2s0";

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_4.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_4.pan
@@ -1,0 +1,6 @@
+object template pxelinux_ks_ksdevice_systemd_scheme_4;
+
+include 'pxelinux_ks';
+
+prefix "/system/aii/nbp/pxelinux";
+"ksdevice" = "enx78e7d1ea46da";


### PR DESCRIPTION
As documented at:
  * http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
  * https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/ch-Consistent_Network_Device_Naming.html

This is the AII counterpart to quattor/configuration-modules-core#528.