### PR TITLE
aii-ks: spma uses boolean_yes_no for proxy enabling

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -52,7 +52,6 @@ use constant { KS               => "/system/aii/osinstall/ks",
                ACKURL           => "/system/aii/osinstall/ks/ackurl",
                ACKLIST          => "/system/aii/osinstall/ks/acklist",
                CARDS            => "/hardware/cards/nic",
-               SPMAPROXY        => "/software/components/spma/proxy",
                SPMA             => "/software/components/spma",
                SPMA_OBSOLETES   => "/software/components/spma/process_obsoletes",
                ROOTMAIL         => "/system/rootmail",
@@ -919,10 +918,15 @@ sub proxy
 {
     my ($config) = @_;
     my ($proxyhost, $proxyport, $proxytype);
-    if ($config->elementExists (SPMAPROXY)) {
-        my $spma = $config->getElement (SPMA)->getTree;
-        my $proxy_host = $spma->{proxyhost};
-        my @proxies = split /,/,$proxy_host;
+
+    my $spma = $config->getTree(SPMA);
+    my $use_proxy = $spma->{proxy} || 0;
+    # old SPMA boolean_yes_no schema
+    $use_proxy = $use_proxy eq "yes" ? 1 : 0;
+
+    if ($use_proxy) {
+        my $tmp_proxyhost = $spma->{proxyhost};
+        my @proxies = split /,/, $tmp_proxyhost;
         if (scalar(@proxies) == 1) {
             # there's only one proxy specified
             $proxyhost = $spma->{proxyhost};
@@ -939,6 +943,7 @@ sub proxy
             $proxytype = $spma->{proxytype};
         }
     }
+
     return ($proxyhost, $proxyport, $proxytype);
 }
 

--- a/aii-ks/src/test/perl/kickstart_proxy.t
+++ b/aii-ks/src/test/perl/kickstart_proxy.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Quattor qw(kickstart_proxy kickstart_noproxy);
+use NCM::Component::ks;
+use CAF::FileWriter;
+use CAF::Object;
+
+=pod
+
+=head1 SYNOPSIS
+
+Tests for the C<proxy> method.
+
+=cut
+
+$CAF::Object::NoAction = 1;
+
+
+my $cfg = get_config_for_profile('kickstart_proxy');
+
+is_deeply([NCM::Component::ks::proxy($cfg)],
+          [qw(proxy.server1 1234 forward)],
+          "Return expected proxy config");
+
+$cfg = get_config_for_profile('kickstart_noproxy');
+
+is_deeply([NCM::Component::ks::proxy($cfg)],
+          [undef,undef,undef],
+          "undef/disabled proxy config");
+
+done_testing();

--- a/aii-ks/src/test/resources/kickstart_noproxy.pan
+++ b/aii-ks/src/test/resources/kickstart_noproxy.pan
@@ -1,0 +1,11 @@
+object template kickstart_noproxy;
+
+include 'kickstart';
+
+prefix "/software/components/spma";
+# beware of crappy legacy schema
+"proxy" = "no"; 
+
+"proxyhost" = "proxy.server,LOCALHOST";  # comma-separated list of proxy hosts
+"proxyport" = "1234"; # yes, this is a string in the spma schema
+"proxytype" = 'forward';

--- a/aii-ks/src/test/resources/kickstart_proxy.pan
+++ b/aii-ks/src/test/resources/kickstart_proxy.pan
@@ -1,0 +1,11 @@
+object template kickstart_proxy;
+
+include 'kickstart';
+
+prefix "/software/components/spma";
+# beware of crappy legacy schema
+"proxy" = "yes";
+
+"proxyhost" = "proxy.server1,proxy.server2";  # comma-separated list of proxy hosts
+"proxyport" = "1234"; # yes, this is a string in the spma schema
+"proxytype" = 'forward';


### PR DESCRIPTION
When the `spma` `proxy` attribute is used to toggle proxy configuration, it's value is ignored (only existence is checked), leading to wrong configuration or in best case, some `uninitialized value` warnings.