### PR TITLE
aii-opennebula: include support to set different RPC cloud domains

### DIFF
--- a/aii-opennebula/src/main/perl/opennebula.pm
+++ b/aii-opennebula/src/main/perl/opennebula.pm
@@ -44,7 +44,7 @@ sub make_one
     $config = Config::Tiny->read($filename);
     if (exists($config->{$domainname})) {
         $rpc = $domainname;
-        $main::this_app->info ("Detected configfile RPC section: [$domainname]");
+        $main::this_app->info ("Detected configfile RPC section: [$rpc]");
     };
     my $port = $config->{$rpc}->{port} || 2633;
     my $host = $config->{$rpc}->{host} || "localhost";

--- a/aii-opennebula/src/main/perl/opennebula.pm
+++ b/aii-opennebula/src/main/perl/opennebula.pm
@@ -44,6 +44,7 @@ sub make_one
     $config = Config::Tiny->read($filename);
     if (exists($config->{$domainname})) {
         $rpc = $domainname;
+        $main::this_app->info ("Detected configfile RPC section: [$domainname]");
     };
     my $port = $config->{$rpc}->{port} || 2633;
     my $host = $config->{$rpc}->{host} || "localhost";
@@ -51,7 +52,7 @@ sub make_one
     my $password = $config->{$rpc}->{password};
 
     if (! $password ) {
-        $main::this_app->error("No password set in configfile $filename.");
+        $main::this_app->error("No password set in configfile $filename. Section [$rpc]");
         return;
     }
     

--- a/aii-opennebula/src/main/perl/opennebula.pm
+++ b/aii-opennebula/src/main/perl/opennebula.pm
@@ -29,8 +29,9 @@ use constant MINIMAL_ONE_VERSION => version->new("4.8.0");
 #   password=secret
 sub make_one 
 {
-    my $self = shift;
-    my $filename = shift || AII_OPENNEBULA_CONFIG;
+    my ($self, $data) = @_;
+    my $filename = AII_OPENNEBULA_CONFIG;
+    my $rpc = "rpc";
 
     if (! -f $filename) {
         $main::this_app->error("No configfile $filename.");
@@ -38,12 +39,16 @@ sub make_one
     }
 
     my $config = Config::Tiny->new;
+    my $domainname = $data->getElement (DOMAINNAME)->getValue;
 
     $config = Config::Tiny->read($filename);
-    my $port = $config->{rpc}->{port} || 2633;
-    my $host = $config->{rpc}->{host} || "localhost";
-    my $user = $config->{rpc}->{user} || "oneadmin";
-    my $password = $config->{rpc}->{password};
+    if (exists($config->{$domainname})) {
+        $rpc = $domainname;
+    };
+    my $port = $config->{$rpc}->{port} || 2633;
+    my $host = $config->{$rpc}->{host} || "localhost";
+    my $user = $config->{$rpc}->{user} || "oneadmin";
+    my $password = $config->{$rpc}->{password};
 
     if (! $password ) {
         $main::this_app->error("No password set in configfile $filename.");
@@ -479,7 +484,7 @@ sub configure
     my $fqdn = $self->get_fqdn($config);
 
     # Set one endpoint RPC connector
-    my $one = make_one();
+    my $one = $self->make_one($config);
     if (!$one) {
         $main::this_app->error("No ONE instance returned");
         return 0;
@@ -520,7 +525,7 @@ sub install
     my $fqdn = $self->get_fqdn($config);
 
     # Set one endpoint RPC connector
-    my $one = make_one();
+    my $one = $self->make_one($config);
     if (!$one) {
         $main::this_app->error("No ONE instance returned");
         return 0;
@@ -598,7 +603,7 @@ sub remove
     my $fqdn = $self->get_fqdn($config);
 
     # Set one endpoint RPC connector
-    my $one = make_one();
+    my $one = $self->make_one($config);
     if (!$one) {
         $main::this_app->error("No ONE instance returned");
         return 0;

--- a/aii-opennebula/src/main/perl/opennebula.pod
+++ b/aii-opennebula/src/main/perl/opennebula.pod
@@ -98,9 +98,11 @@ Remove VM templates
 
 =back
 
+=back
+
 =head2 DEPENDENCIES
 
-The AII was tested with OpenNebula version 4.8 and 4.10
+The AII was tested with OpenNebula version 4.8 and 4.1x
 
 Following package dependencies should be installed to run the AII:
 
@@ -113,6 +115,40 @@ Following package dependencies should be installed to run the AII:
 =item * perl-Set-Scalar
 
 =item * perl-Net-OpenNebula >= 0.2.2 !
+
+=back
+
+Set OpenNebula endpoints RPC connector /etc/aii/opennebula.conf
+
+It must include at least one RPC endpoint and password.
+
+By default ONE AII uses oneadmin user.
+
+It is also possible to set a different endpoint for each VM domain, as example:
+
+=over 
+
+=item [rpc]
+
+=item password=
+
+=item host=
+
+
+=item [VM_DOMAIN_NAME1]
+
+=item password=
+
+=item user=
+
+=item host=
+
+
+=item [VM_DOMAIN_NAME2]
+
+=item password=
+
+=item host=
 
 =back
 

--- a/aii-opennebula/src/main/perl/opennebula.pod
+++ b/aii-opennebula/src/main/perl/opennebula.pod
@@ -122,7 +122,7 @@ Set OpenNebula endpoints RPC connector /etc/aii/opennebula.conf
 
 It must include at least one RPC endpoint and password.
 
-By default ONE AII uses oneadmin user.
+By default ONE AII uses oneadmin user and port 2633.
 
 It is also possible to set a different endpoint for each VM domain, as example:
 
@@ -134,6 +134,7 @@ It is also possible to set a different endpoint for each VM domain, as example:
     password=
     user=
     host=
+    port=
 
     [VM_DOMAIN_NAME2]
     password=

--- a/aii-opennebula/src/main/perl/opennebula.pod
+++ b/aii-opennebula/src/main/perl/opennebula.pod
@@ -126,31 +126,18 @@ By default ONE AII uses oneadmin user.
 
 It is also possible to set a different endpoint for each VM domain, as example:
 
-=over 
+    [rpc]
+    password=
+    host=
 
-=item [rpc]
+    [VM_DOMAIN_NAME1]
+    password=
+    user=
+    host=
 
-=item password=
-
-=item host=
-
-
-=item [VM_DOMAIN_NAME1]
-
-=item password=
-
-=item user=
-
-=item host=
-
-
-=item [VM_DOMAIN_NAME2]
-
-=item password=
-
-=item host=
-
-=back
+    [VM_DOMAIN_NAME2]
+    password=
+    host=
 
 =head2 AUTHOR
 


### PR DESCRIPTION
 * Fix #142 : include support to set different cloud domains into /etc/aii/opennebula.conf