### PR TITLE
ks: double escaped variables in yum.conf heredoc-in-heredoc

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -1260,7 +1260,7 @@ sub yum_setup
 mkdir -p /tmp/aii/yum/repos
 cat <<end_of_yum_conf > /tmp/aii/yum/yum.conf
 [main]
-cachedir=/var/cache/yum/\$basearch/\$releasever
+cachedir=/var/cache/yum/\\\$basearch/\\\$releasever
 keepcache=0
 debuglevel=2
 logfile=/var/log/yum.log

--- a/aii-ks/src/test/resources/regexps/kickstart_yum_setup
+++ b/aii-ks/src/test/resources/regexps/kickstart_yum_setup
@@ -4,7 +4,7 @@ Test the yum_setup
 ^mkdir -p /tmp/aii/yum/repos$
 ^cat <<end_of_yum_conf > /tmp/aii/yum/yum.conf$
 ^\[main\]$
-^cachedir=/var/cache/yum/\$basearch/\$releasever$
+^cachedir=/var/cache/yum/\\\$basearch/\\\$releasever$
 ^keepcache=0$
 ^debuglevel=2$
 ^logfile=/var/log/yum.log$


### PR DESCRIPTION
Fixes #153 