### PR TITLE
aii-opennebula: var without default

### DIFF
--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
@@ -6,6 +6,8 @@ include 'quattor/aii/opennebula/functions';
 #  undef are set via schema default
 variable OPENNEBULA_AII_FORCE ?= undef; 
 variable OPENNEBULA_AII_ONHOLD ?= undef;
+variable OPENNEBULA_AII_FORCE_REMOVE ?= false;
+
 variable MAC_PREFIX ?= '02:00';
 
 "/system/aii/hooks/configure/" = {


### PR DESCRIPTION
without this, template-library-core fails for https://github.com/quattor/template-library-core/pull/99