### PR TITLE
ks: add useexisting when using el7 with md

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -551,7 +551,10 @@ EOF
                 ! $fstree->{ksfsformat}) {
             $fstree->{ksfsformat}=1;
         }
-
+        if ($version >= ANACONDA_VERSION_EL_7_0) {
+             $fstree->{useexisting_md} = 1;
+        }
+  
         $fstree->print_ks;
     }
 }
@@ -823,6 +826,13 @@ EOF
     ksuserhooks ($config, PREENDHOOK);
 
     my $end = $config->getElement(END_SCRIPT_FIELD)->getValue();
+    my $kstree = $config->getElement(KS)->getTree;
+    my $version = get_anaconda_version($kstree);
+
+    # mdadm devices should be stopped at the end of the pre-ks phase on EL7
+    if ($version >= ANACONDA_VERSION_EL_7_0) {
+        print "mdadm --stop --scan";
+    } 
 
     print <<EOF;
 

--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -831,7 +831,7 @@ EOF
 
     # mdadm devices should be stopped at the end of the pre-ks phase on EL7
     if ($version >= ANACONDA_VERSION_EL_7_0) {
-        print "mdadm --stop --scan";
+        print "mdadm --stop --scan\n";
     } 
 
     print <<EOF;

--- a/aii-ks/src/test/perl/kickstart_mounts.t
+++ b/aii-ks/src/test/perl/kickstart_mounts.t
@@ -26,7 +26,7 @@ my $cfg = get_config_for_profile('kickstart_mounts');
 NCM::Component::ks::ksmountpoints($cfg);
 like($fh, qr{^part swap --onpart sdb1 --fstype=swap --fsoptions='auto'\s$}m, 'swap part ok for el7');
 unlike ($fh, qr{sdb1.*--noformat}m, 'swap part has no noformat option');
-
+like($fh, qr{raid /boot --device=md1 --noformat --useexisting}m, 'raid with el7 uses useexisting');
 # close the selected FH and reset STDOUT
 NCM::Component::ks::ksclose;
 

--- a/aii-ks/src/test/perl/kickstart_pre.t
+++ b/aii-ks/src/test/perl/kickstart_pre.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Quattor qw(kickstart_pre_noblock kickstart_pre_blocksize);
+use Test::Quattor qw(kickstart_pre_noblock kickstart_pre_blocksize kickstart_pre_mdstop kickstart_pre_nomdstop);
 use Test::Quattor::RegexpTest;
 use NCM::Component::ks;
 use CAF::FileWriter;
@@ -20,7 +20,7 @@ $CAF::Object::NoAction = 1;
 
 my $regexpdir= getcwd()."/src/test/resources/regexps";
 
-my @tests = qw(noblock blocksize);
+my @tests = qw(noblock blocksize mdstop nomdstop);
 foreach my $test (@tests) {
     my $fh = CAF::FileWriter->new("target/test/ks_pre_noblock_$test");
     # This module simply prints to the default filehandle.

--- a/aii-ks/src/test/resources/kickstart_mounts.pan
+++ b/aii-ks/src/test/resources/kickstart_mounts.pan
@@ -23,7 +23,15 @@ prefix "/system/aii/osinstall/ks";
             "size", 100,
             "type", "primary", # no defaults !
         ),
-    )
+    ),
+    "md", dict(
+        "md1", dict (
+            "device_list", list ("partitions/sdb1"),
+            "raid_level", "RAID0",
+            "stripe_size", 64, 
+            ),
+    ),
+
 );
 
 "/system/filesystems" = list (
@@ -37,5 +45,16 @@ prefix "/system/aii/osinstall/ks";
         "type", "swap",
         "freq", 0,
         "pass", 1
-    )
+    ),
+    dict(
+        "mount", true,
+        "mountpoint", "/boot",
+        "preserve", true,
+        "format", false,
+        "mountopts", "auto",
+        "block_device", "md/md1",
+        "type", "ext4",
+        "freq", 0,
+        "pass", 1
+    ),
 );

--- a/aii-ks/src/test/resources/kickstart_pre_mdstop.pan
+++ b/aii-ks/src/test/resources/kickstart_pre_mdstop.pan
@@ -1,0 +1,12 @@
+@{ 
+Profile to verify the kickstart %pre
+@}
+
+object template kickstart_pre_mdstop;
+
+include 'kickstart';
+
+prefix "/system/aii/osinstall/ks";
+"version" = "19.31";
+
+

--- a/aii-ks/src/test/resources/kickstart_pre_nomdstop.pan
+++ b/aii-ks/src/test/resources/kickstart_pre_nomdstop.pan
@@ -1,0 +1,8 @@
+@{ 
+Profile to verify the kickstart %pre
+@}
+
+object template kickstart_pre_nomdstop;
+
+include 'kickstart';
+

--- a/aii-ks/src/test/resources/regexps/pre_mdstop_blockdevices
+++ b/aii-ks/src/test/resources/regexps/pre_mdstop_blockdevices
@@ -1,0 +1,4 @@
+Test the mdstop in the pre section
+---
+---
+^mdadm --stop --scan$

--- a/aii-ks/src/test/resources/regexps/pre_nomdstop_blockdevices
+++ b/aii-ks/src/test/resources/regexps/pre_nomdstop_blockdevices
@@ -1,0 +1,4 @@
+Test the mdstop in the pre section
+---
+---
+^mdadm --stop --scan$ ### COUNT 0


### PR DESCRIPTION
fixes #102 
depends on https://github.com/quattor/ncm-lib-blockdevices/pull/64

On EL7 Anaconda, mdadm should stop the devices at the end of the pre section, 
and should add the --useexisting flag on the already created MD devices.