### PR TITLE
aii-ks: sha512 instead of md5 for password hashes

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/config.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/config.pan
@@ -295,9 +295,9 @@ variable  AII_OSINSTALL_BOOTPROTO ?= 'dhcp';
 
 #
 # Options for authentication
-# defaults to using shadow passwords and MD5 hashing
+# defaults to using shadow passwords and sha512 hashing
 #
-variable AII_OSINSTALL_OPTION_AUTH ?= list ("enableshadow", "enablemd5");
+variable AII_OSINSTALL_OPTION_AUTH ?= list ("enableshadow", "passalgo=sha512");
 "/system/aii/osinstall/ks/auth" ?= AII_OSINSTALL_OPTION_AUTH;
 #
 # Firewall

--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -57,7 +57,7 @@ type structure_ks_logging = {
 type structure_ks_ks_info = {
     "ackurl"	: type_absoluteURI
     "acklist"	? type_absoluteURI[]
-    "auth"		: string[] = list ("enableshadow", "enablemd5")
+    "auth" : string[] = list ("enableshadow", "passalgo=sha512")
     "bootloader_location" : string = "mbr"
     "bootloader_append" ? string
     "bootloader_password" ? string

--- a/aii-ks/src/main/perl/ks.pod
+++ b/aii-ks/src/main/perl/ks.pod
@@ -34,8 +34,8 @@ If acklist is set, then ackurl is not used.
 
 =item * auth : string[]
 
-List of options for authentication. Defaults to ("enableshadow", "enablemd5").
-i.e. enable shadow passwords and MD5 hashing.
+List of options for authentication. Defaults to ("enableshadow", "passalgo=sha512").
+i.e. enable shadow passwords and sha512 hashing.
 
 =item * bonding : boolean
 
@@ -458,8 +458,8 @@ the network via DHCP.
 
 =item * AII_OSINSTALL_OPTION_AUTH : string[]
 
-List of options for the authorization system. By default, MD5 shadowed
-passwords are enabled, this is C<list ("enableshadow", "enablemd5")>
+List of options for the authorization system. By default, sha512 shadowed
+passwords are enabled, this is C<list ("enableshadow", "passalgo=sha512")>
 
 =item * AII_OSINSTALL_OPTION_FIREWALL ? firewal
 

--- a/aii-ks/src/test/perl/kickstart_commands.t
+++ b/aii-ks/src/test/perl/kickstart_commands.t
@@ -28,7 +28,7 @@ NCM::Component::ks::kscommands($cfg);
 like($fh, qr{^text}m, 'text mode install present');
 like($fh, qr{^reboot}m, 'reboot after install present');
 like($fh, qr{^skipx}m, 'skip x configuration present');
-like($fh, qr{^auth\s--enableshadow\s--enablemd5}m, 'authentication parameters present');
+like($fh, qr{^auth\s--enableshadow\s--passalgo=sha512}m, 'authentication parameters present');
 like($fh, qr{^install\n^url\s--url http://baseos}m, 'installtype present');
 like($fh, qr{^timezone\s--utc Europe/SomeCity}m, 'timezone present');
 like($fh, qr{^rootpw\s--iscrypted veryverysecret}m, 'crypted root password present');

--- a/aii-ks/src/test/perl/kickstart_el7_static_ip.t
+++ b/aii-ks/src/test/perl/kickstart_el7_static_ip.t
@@ -29,7 +29,7 @@ like($fh, qr{^cmdline}m, 'cmdline mode install present');
 
 like($fh, qr{^reboot}m, 'reboot after install present');
 like($fh, qr{^skipx}m, 'skip x configuration present');
-like($fh, qr{^auth\s--enableshadow\s--enablemd5}m, 'authentication parameters present');
+like($fh, qr{^auth\s--enableshadow\s--passalgo=sha512}m, 'authentication parameters present');
 like($fh, qr{^install\n^url\s--url http://baseos}m, 'installtype present');
 like($fh, qr{^timezone\s--utc Europe/SomeCity}m, 'timezone present');
 like($fh, qr{^rootpw\s--iscrypted veryverysecret}m, 'crypted root password present');

--- a/aii-ks/src/test/resources/kickstart.pan
+++ b/aii-ks/src/test/resources/kickstart.pan
@@ -32,7 +32,7 @@ prefix "/system/aii/osinstall/ks";
 "rootpw" = "veryverysecret";
 "osinstall_protocol" = "https";
 "ackurl" = "http://ack";
-"auth" = list ("enableshadow", "enablemd5");
+"auth" = list ("enableshadow", "passalgo=sha512");
 "bootloader_location" = "mbr";
 "bootloader_append" = 'append something';
 "bootloader_password" = "$1$ZAOkBwVp$Cs5cO5cfaqzH5AdZ/jpjP/"; # "Quattor"


### PR DESCRIPTION
md5 is too fast, therefore much easier to brute-force.

This changes the default password hashing algorithm to sha512.