### PR TITLE
Disable CCM tabcompletion during aii-shellfe runs

### DIFF
--- a/aii-core/src/main/perl/aii-shellfe
+++ b/aii-core/src/main/perl/aii-shellfe
@@ -928,6 +928,7 @@ sub fetch_profiles
         } else {
             print $cfg_fh "cache_root $ccmdir\n";
             print $cfg_fh "json_typed $json_typed\n";
+            print $cfg_fh "tabcompletion 0\n";
 
             my $changed = $cfg_fh->close() ? "" : "not";
             $self->debug(1, "config file $config $changed changed.");


### PR DESCRIPTION
Otherwise a lot of time is wasted generating useless tabcompletion files.

See #193.

This will be used to build a point release of AII.