### PR TITLE
ks: schema: bonding is optional and best-effort when not defined

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/config.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/config.pan
@@ -3,12 +3,13 @@
 # ${author-info}
 # ${build-info}
 
-# Template containing the Kickstart-related configuration and default
-# values.
+@{Template containing the Kickstart-related configuration and default values.}
 
-template quattor/aii/ks/config;
+unique template quattor/aii/ks/config;
 
 include 'quattor/aii/ks/schema';
+
+bind "/system/aii/osinstall/ks" = structure_ks_ks_info;
 
 variable AII_DOMAIN ?= value('/system/network/domainname');
 variable AII_HOSTNAME ?= value('/system/network/hostname');
@@ -424,4 +425,3 @@ variable AII_OSINSTALL_BASE_PACKAGES ?= list (
 # Define if volgroup statement is required for LVM-based file systems.
 # Default is for SL4/5
 "/system/aii/osinstall/ks/volgroup_required" = true;
-

--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -2,15 +2,20 @@
 # ${developer-info}
 # ${author-info}
 # ${build-info}
-# Structure for the component generating kickstart files.
 
-unique template quattor/aii/ks/schema;
+@{Structure for the component generating kickstart files.}
 
-# X configuration on the KS file. Might deserve a component for
-# itself.
+declaration template quattor/aii/ks/schema;
+
+include 'pan/types';
+
+@documentation{
+    X configuration on the KS file.
+}
 type structure_ks_ksxinfo = {
-    "card"		? string # Graphics card driver
-    "monitor"	? string #
+    @{Graphics card driver}
+    "card"		? string
+    "monitor"	? string
     "noprobe"	? string
     "vsync"		? long
     "hsync"		? long
@@ -23,7 +28,9 @@ type structure_ks_ksxinfo = {
 
 type string_ksservice = string with match (SELF, "^(ssh|telnet|smtp|http|ftp)$");
 
-# Information needed for configuring the firewall at installation-time.
+@documentation{
+    Configure the firewall at installation-time.
+}
 type structure_ks_ksfirewall = {
     "enabled"	: boolean = true
     "trusted"	? string []
@@ -31,29 +38,32 @@ type structure_ks_ksfirewall = {
     "ports"		: long[] = list (7777)
 };
 
-# Information needed for logging into syslog
-# Anaconda syslog uses UDP
+@documentation{
+    Log to syslog. Anaconda syslog uses UDP
+}
 type structure_ks_logging = {
-    # when host is defined, anaconda syslog will be configured
-    "host" ? type_hostname 
+    @{when host is defined, anaconda syslog will be configured}
+    "host" ? type_hostname
     "port" : type_port = 514
     "level" ? string with match(SELF, "^(debug|warning|error|critical|info)$")
-
-    "console" : boolean = true # redirect AII ks logfile to console 
-    
-    # send AII ks logfile to host/port 
+    @{redirect AII ks logfile to console }
+    "console" : boolean = true
+    @{send AII ks logfile to host/port}
     "send_aiilogs" : boolean = false
-
-    # use legacy defaults 
-    # via bash or netcat
-    "method" : string = 'netcat' with match(SELF, '^(bash|netcat)$') 
-    # via tcp or udp
+    # use legacy defaults
+    @{send_aiilogs via bash or netcat}
+    "method" : string = 'netcat' with match(SELF, '^(bash|netcat)$')
+    @{send_aiilogs via tcp or udp}
     "protocol" : string = 'udp' with match(SELF, '^(tcp|udp)$')
 } with {
     (! SELF['send_aiilogs']) || is_defined(SELF['host'])
 };
 
-# Information needed for creating the Kickstart file
+@documentation{
+    Information needed for creating the Kickstart file
+    Optional hooks pre_install, post_install, post_reboot and install
+    for user customization are under /system/ks/hooks/.
+}
 type structure_ks_ks_info = {
     "ackurl"	: type_absoluteURI
     "acklist"	? type_absoluteURI[]
@@ -72,7 +82,8 @@ type structure_ks_ks_info = {
     "installtype"	: string
     "installnumber" ? string
     "lang"		: string = "en_US.UTF-8"
-    # If you use more than one languages, mark the default one with "--default=your_lang"
+    # TODO: how would you set --default=your_lang in ks?
+    @{If you use more than one language, mark the default one with --default your_lang}
     "langsupport"	? string [] = list ("en_US.UTF-8")
     "logging"	? structure_ks_logging
     "mouse"		? string
@@ -91,26 +102,24 @@ type structure_ks_ks_info = {
     "xwindows"	? structure_ks_ksxinfo
     "disable_service" ? string[]
     "ignoredisk"    ? string[]
-    # Base packages needed for a Quattor client to run (CAF, CCM...)
+    @{Base packages needed for a Quattor client to run (CAF, CCM...)}
     "base_packages" : string[]
-    # Repositories to disable while SPMA is not available
+    @{Repositories to disable while SPMA is not available}
     "disabled_repos" : string[] = list()
-    # Hooks for user customization are under: /system/ks/hooks/{pre_install,
-    # post_install, post_reboot and install}. They
-    # are optional.
     "packages_args" : string[] = list("--ignoremissing","--resolvedeps")
     "end_script" :  string = ""
     "part_label" : boolean = false # Does the "part" stanza support the --label option?
-    # Set to true if volgroup statement is required in KS config file (must not be present for SL6+)
+    @{Set to true if volgroup statement is required in KS config file (must not be present for SL6+)}
     'volgroup_required' : boolean = false
-    
-    'version' : string = '11.1' # anaconda version, default is for EL5.0 support 
-    'cmdline' ? boolean # use cmdline instead of text mode
-    'eula' ? boolean # agree with EULA (EL7+)
+    @{anaconda version, default is for EL5.0 support}
+    'version' : string = '11.1'
+    @{use cmdline instead of text mode}
+    'cmdline' ? boolean
+    @{agree with EULA (EL7+)}
+    'eula' ? boolean
     'packagesinpost' ? boolean
-    'bonding' : boolean = true # support network bonding
+    @{configure bonding}
+    'bonding' : boolean = true
     'lvmforce' ? boolean
     'init_spma_ignore_deps' ? boolean
 };
-
-bind "/system/aii/osinstall/ks" = structure_ks_ks_info;

--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -118,8 +118,8 @@ type structure_ks_ks_info = {
     @{agree with EULA (EL7+)}
     'eula' ? boolean
     'packagesinpost' ? boolean
-    @{configure bonding}
-    'bonding' : boolean = true
+    @{configure bonding (when not defined, it will be tried best-effort depending on OS version and configuration)}
+    'bonding' ? boolean
     'lvmforce' ? boolean
     'init_spma_ignore_deps' ? boolean
 };

--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -221,10 +221,11 @@ sub ksnetwork_get_dev_net
         push(@networkopts, "--bondslaves=".join(',', @slaves));
 
         # gather the options
-        if ($net->{bonding_opts}) {
+        my $bond_opts = $net->{bonding_opts};
+        if ($bond_opts) {
             my @opts;
-            while (my ($k, $v) = each(%{$net->{bonding_opts}})) {
-                push(@opts, "$k=$v");
+            foreach my $key (sort keys %$bond_opts) {
+                push(@opts, "$key=".$bond_opts->{$key});
             }
             push(@networkopts, "--bondopts=".join(',', @opts));
         }
@@ -554,7 +555,7 @@ EOF
         if ($version >= ANACONDA_VERSION_EL_7_0) {
              $fstree->{useexisting_md} = 1;
         }
-  
+
         $fstree->print_ks;
     }
 }
@@ -832,7 +833,7 @@ EOF
     # mdadm devices should be stopped at the end of the pre-ks phase on EL7
     if ($version >= ANACONDA_VERSION_EL_7_0) {
         print "mdadm --stop --scan\n";
-    } 
+    }
 
     print <<EOF;
 

--- a/aii-ks/src/test/resources/kickstart.pan
+++ b/aii-ks/src/test/resources/kickstart.pan
@@ -24,6 +24,10 @@ prefix "/software/packages";
 prefix "/system/aii/nbp/pxelinux";
 "ksdevice" = "eth0";
 
+include 'quattor/aii/ks/schema';
+
+bind "/system/aii/osinstall/ks" = structure_ks_ks_info;
+
 prefix "/system/aii/osinstall/ks";
 "bootproto" = "dhcp"; 
 "keyboard" = "us";

--- a/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/config.pan
+++ b/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/config.pan
@@ -2,9 +2,12 @@
 # ${developer-info}
 # ${author-info}
 # ${build-info}
-template quattor/aii/pxelinux/config;
+
+unique template quattor/aii/pxelinux/config;
 
 include 'quattor/aii/pxelinux/schema';
+
+bind "/system/aii/nbp/pxelinux" = structure_pxelinux_pxe_info;
 
 @documentation{
     Use sys/pxelinux with lpxelinux.0
@@ -56,26 +59,20 @@ variable AII_NBP_LABEL ?= {
     if ( !is_defined(AII_OSINSTALL_OS_VERSION) ) {
         return(undef);
     };
+
+    labelmap = dict(
+        'centos', 'CentOS',
+        'fedora', 'Fedora',
+        'sl', 'Scientific Linux',
+        'slc', 'Scientific Linux CERN',
+        'rhel', 'Red Hat Entreprise Linux',
+    );
+
     toks =  matches(AII_OSINSTALL_OS_VERSION, '^(slc?|rhel|centos|fedora)(\w+?)[_\-](.*)');
-    if ( length(toks) < 4 ) {
+    if ( length(toks) < 4 || ! is_defined(labelmap[toks[1]])) {
         label = undef;
     } else {
-        if ( toks[1] == 'centos' ) {
-            label = 'CentOS ';
-        } else if ( toks[1] == 'fedora' ) {
-            label = 'Fedora ';
-        } else if ( toks[1] == 'sl' ) {
-            label = 'Scientific Linux ';
-        } else if ( toks[1] == 'slc' ) {
-            label = 'Scientific Linux CERN ';
-        } else if ( toks[1] == 'rhel' ) {
-            label = 'Red Hat Entreprise Linux ';
-        } else {
-            label = undef;
-        };
-        if ( is_defined(label) ) {
-            label = label + toks[2] + ' ('+ toks[3] + ')';
-        };
+        label = format("%s %s (%s)", labelmap[toks[1]], toks[2], toks[3]);
     };
     label;
 };

--- a/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
+++ b/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
@@ -2,9 +2,14 @@
 # ${developer-info}
 # ${author-info}
 # ${build-info}
-unique template quattor/aii/pxelinux/schema;
 
-# PXE configuration.
+declaration template quattor/aii/pxelinux/schema;
+
+include 'pan/types';
+
+@documentation{
+    PXE configuration
+}
 type structure_pxelinux_pxe_info = {
     "initrd"	: string
     "kernel"	: string
@@ -18,5 +23,3 @@ type structure_pxelinux_pxe_info = {
     "setifnames" ? boolean
     "updates" ? type_absoluteURI
 };
-
-bind "/system/aii/nbp/pxelinux" = structure_pxelinux_pxe_info;

--- a/aii-pxelinux/src/test/resources/pxelinux_no_append.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_no_append.pan
@@ -1,9 +1,13 @@
-@{ 
+@{
 Base pxelinux without append data
 @}
 template pxelinux_no_append;
 
-prefix "/system/network"; 
+include 'quattor/aii/pxelinux/schema';
+
+bind "/system/aii/nbp/pxelinux" = structure_pxelinux_pxe_info;
+
+prefix "/system/network";
 "hostname" = 'x';
 "domainname" = 'y';
 "nameserver/0" = 'nm1';
@@ -13,8 +17,8 @@ prefix "/system/network";
 "interfaces/eth0/netmask" = "255.255.255.0";
 
 prefix "/hardware/cards/nic";
-"eth0/hwaddr" = "00:11:22:33:44:55"; 
-"eth1/hwaddr" = "00:11:22:33:44:66"; 
+"eth0/hwaddr" = "00:11:22:33:44:55";
+"eth1/hwaddr" = "00:11:22:33:44:66";
 
 
 prefix "/system/aii/nbp/pxelinux";

--- a/aii-pxelinux/src/test/resources/pxelinux_no_append_block.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_no_append_block.pan
@@ -1,3 +1,7 @@
 object template pxelinux_no_append_block;
 
 include 'pxelinux_no_append';
+
+prefix "/system/aii/nbp/pxelinux";
+"ksdevice" = "eth0";
+"kslocation" = "http://server/ks";


### PR DESCRIPTION
Solves the reported error in https://github.com/quattor/aii/issues/200 when a macaddress is used as ksdevice