### PR TITLE
aii-pxelinux: substitute LOCALHOST on profile append

### DIFF
--- a/aii-pxelinux/src/main/perl/pxelinux.pm
+++ b/aii-pxelinux/src/main/perl/pxelinux.pm
@@ -332,9 +332,13 @@ sub pxe_ks_append
             push(@append,"nameserver=$ns");
         }
     }
-        
-    push(@append, $t->{append}) if $t->{append};
 
+    my $custom_append = $t->{append};
+    if ($custom_append) {
+	    $custom_append =~ s/LOCALHOST/$server/g;
+	    push @append, $custom_append;
+    }
+    
     return @append;    
 }
 

--- a/aii-pxelinux/src/test/perl/pxelinux_ks_block.t
+++ b/aii-pxelinux/src/test/perl/pxelinux_ks_block.t
@@ -5,6 +5,7 @@ use Test::Quattor qw(pxelinux_ks_block);
 use NCM::Component::pxelinux;
 use CAF::FileWriter;
 use CAF::Object;
+use Sys::Hostname;
 
 =pod
 
@@ -27,6 +28,7 @@ my $cfg = get_config_for_profile('pxelinux_ks_block');
 NCM::Component::pxelinux::pxeprint($cfg);
 
 my $fh = get_file($fp);
+my $hostname = hostname();
 
 like($fh, qr{^default\skernel\slabel}m, 'default kernel');
 like($fh, qr{^\s{4}label\skernel\slabel}m, 'label default kernel');
@@ -35,6 +37,6 @@ like($fh, qr{^\s{4}append\sramdisk=32768\sinitrd=path/to/initrd(\s|$)}m, 'append
 like($fh, qr{^\s{4}append.*?\sks=http://server/ks(\s|$)}m, 'append ks url');
 like($fh, qr{^\s{4}append.*?\sksdevice=eth0(\s|$)}m, 'append ksdevice');
 like($fh, qr{^\s{4}append.*?\supdates=http://somewhere/somthing/updates.img(\s|$)}m, 'append ksdevice');
-
+like($fh, qr{^\s{4}append.*?\sinst.stage2=http://$hostname/stage2.img}m, 'hostname substitution in append');
 
 done_testing();

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_block.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_block.pan
@@ -4,3 +4,4 @@ include 'pxelinux_ks';
 
 prefix "/system/aii/nbp/pxelinux";
 "updates" = "http://somewhere/somthing/updates.img";
+"append" = "inst.stage2=http://LOCALHOST/stage2.img";


### PR DESCRIPTION
We do this for the kickstart URL but it can be useful for parameters
specified in templates using "append" from the profile.