### PR TITLE
aii-opennebula: Add VM image driver option

### DIFF
--- a/aii-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/aii-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -188,6 +188,8 @@ type opennebula_vmtemplate = {
     "ignoremac" ? opennebula_ignoremac
     "graphics"  : string = 'VNC' with match (SELF, '^(VNC|SDL|SPICE)$')
     "diskcache" ? string with match(SELF, '^(default|none|writethrough|writeback|directsync|unsafe)$')
+    @{specific image mapping driver. qcow2 is not supported by Ceph storage backends}
+    "diskdriver" ? string with match(SELF, '^(raw|qcow2)$')
     "permissions" ? opennebula_permissions
     "pci" ? opennebula_vmtemplate_pci[]
     @{labels is a list of strings to group the VMs under a given name and filter them 

--- a/aii-opennebula/src/main/resources/imagetemplate.tt
+++ b/aii-opennebula/src/main/resources/imagetemplate.tt
@@ -11,6 +11,10 @@ DESCRIPTION = "QUATTOR image for [% fqdn %]: [% pair.key %]"
 [%- IF system.opennebula.labels.defined %]
 LABELS = "[% system.opennebula.labels.join(',') %]"
 [%- END %]
+[%- IF system.opennebula.diskdriver.defined %]
+DRIVER = "[% system.opennebula.diskdriver %]"
+FSTYPE = "[% system.opennebula.diskdriver %]"
+[%- END %]
 QUATTOR = 1
 [% # If we have several disks we have to split vmtemplate in several files
    # Using DATASTORE line. THIS MUST BE THE LAST TT FILE LINE-%]

--- a/aii-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/aii-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -147,6 +147,8 @@ prefix "/system/opennebula";
 
 "diskcache" = "default";
 
+"diskdriver" = "raw";
+
 "ignoremac/interface" = list (
     "eth2",
 );

--- a/aii-opennebula/src/main/resources/tests/regexps/aii_imagetemplate/image_template
+++ b/aii-opennebula/src/main/resources/tests/regexps/aii_imagetemplate/image_template
@@ -14,5 +14,7 @@ multiline
 ^SIZE\s?=\s?10480$
 ^DESCRIPTION\s?=\s?"QUATTOR image for node630.cubone.os: vdb"$
 ^LABELS\s?=\s?"quattor,quattor/CE"$
+^DRIVER\s?=\s?"raw"$
+^FSTYPE\s?=\s?"raw"$
 ^QUATTOR\s?=\s?1$
 ^DATASTORE\s?=\s?"default"$

--- a/aii-opennebula/src/main/resources/tests/regexps/aii_imagetemplate/simple
+++ b/aii-opennebula/src/main/resources/tests/regexps/aii_imagetemplate/simple
@@ -10,5 +10,7 @@ multiline
 ^SIZE\s?=\s*\d+\s*$
 ^DESCRIPTION\s?=\s*".+"\s*$
 ^LABELS\s?=\s?".+"$
+^DRIVER\s?=\s?".+"$
+^FSTYPE\s?=\s?".+"$
 ^QUATTOR\s?=\s?\d?\s*$
 ^DATASTORE\s?=\s*".+"\s*$

--- a/aii-opennebula/src/test/perl/rpcdata.pm
+++ b/aii-opennebula/src/test/perl/rpcdata.pm
@@ -491,6 +491,8 @@ TARGET = "vda"
 SIZE = 20480
 DESCRIPTION = "QUATTOR image for node630.cubone.os: vda"
 LABELS = "quattor,quattor/CE"
+DRIVER = "raw"
+FSTYPE = "raw"
 QUATTOR = 1
 EOF
 $cmds{rpc_create_image}{params} = [$data, 102];
@@ -507,6 +509,8 @@ TARGET = "vdb"
 SIZE = 10480
 DESCRIPTION = "QUATTOR image for node630.cubone.os: vdb"
 LABELS = "quattor,quattor/CE"
+DRIVER = "raw"
+FSTYPE = "raw"
 QUATTOR = 1
 EOF
 $cmds{rpc_create_image2}{params} = [$data, 102];

--- a/aii-opennebula/src/test/resources/vm.pan
+++ b/aii-opennebula/src/test/resources/vm.pan
@@ -127,6 +127,8 @@ prefix "/system/opennebula";
 
 "diskcache" = "default";
 
+"diskdriver" = "raw";
+
 "ignoremac/interface" = list (
     "eth2",
 );


### PR DESCRIPTION
By default ONE uses raw format but it is possible to use qcow2 as well.
Notice that qcow2 is not supported by Ceph storage backends.

 * Fix #235 : Add qcow2 image support