### PR TITLE
AII:Shellfe: Add option to run methods in parallel

### DIFF
--- a/aii-core/src/main/perl/DHCP.pm
+++ b/aii-core/src/main/perl/DHCP.pm
@@ -422,7 +422,7 @@ sub new_configure_entry
                 MORE_OPT   => $add_txt,
              } );
         $self->debug(2, "AII::DHCP: add new entry: host = $host fqdn = $fqdn mac = $mac");
-        $self->debug(3, "AII::DHCP: add new entry: additional opts: $add_txt");
+        $self->debug(3, "AII::DHCP: add new entry: host = $host additional opts: $add_txt");
     }
 
     return(0);
@@ -461,8 +461,7 @@ sub read_input
         # get input data
         my $fh = CAF::FileReader->new($filename, log => $self);
         if ($EC->error()) {
-            $self->error("AII::DHCP: configurelist error: " .
-                             "file access error $filename");
+            $self->error("AII::DHCP: configurelist error: file access error $filename");
             $error +=1;
         } else {
             $self->debug(2, "AII::DHCP: reading nodes to configure from file: $filename");
@@ -511,10 +510,10 @@ sub update_and_restart
     # restart dhcpd daemon
     if ($changed) {
         if ($self->option('norestart')) {
-            $self->verbose("AII::DHCP: config changed but norestart set!");
+            $self->verbose("AII::DHCP: config $filename changed but norestart set!");
         } else {
             my $cmd = $self->option('restartcmd');
-            $self->debug(1, "AII::DHCP: restarting dhcpd daemon using cmd '$cmd'");
+            $self->info(1, "AII::DHCP: config $filename changed, restarting dhcpd daemon using cmd '$cmd'");
             # expects an arayref
             $self->restart_daemon([split(/\s+/, $cmd)]);
         } 
@@ -524,8 +523,9 @@ sub update_and_restart
     return 1;
 }
 
-# return true if dhcp config need changes
-sub nodes_to_change {
+# return true if nodes need to be configured or removed
+sub nodes_to_change 
+{
     my $self = shift;
     return  return (@{$self->{NTC}} + @{$self->{NTR}}) ? 1 : 0;
 }
@@ -544,9 +544,9 @@ sub configure
 
     # update dhcpd configuration file
     if ($self->nodes_to_change()) {
-		return 1 if (!$self->update_and_restart()) ;
+        return 1 if (!$self->update_and_restart()) ;
     } else {
-        $self->debug(1, "aii-nbp: there are no changes to dhcpd configuration to make");
+        $self->debug(1, "AII:DHCP: no nodes to configure, no changes to dhcp configuration");
     }
 
     return 0;

--- a/aii-core/src/main/perl/DHCP.pm
+++ b/aii-core/src/main/perl/DHCP.pm
@@ -131,14 +131,14 @@ sub restart_daemon
 {
     my ($self, $cmd) = @_;
 
-    $self->debug(3, "aii-dhcp: restarting daemon dhcpd");
+    $self->debug(3, "AII::DHCP: restarting daemon dhcpd");
 
     my $output = CAF::Process->new($cmd, log => $self)->output();
     if ($?) {
-        $self->error("aii-dhcp: error restarting dhcp daemon: $output");
+        $self->error("AII::DHCP: error restarting dhcp daemon: $output");
         return(1);
     } else {
-        $self->verbose("aii-dhcp: daemon restarted: $output");
+        $self->verbose("AII::DHCP: daemon restarted: $output");
     }
 
     return(0);
@@ -176,7 +176,7 @@ sub update_dhcp_config_file
     my @netandmasks = ($text =~ /\n\s*subnet\s+([\d\.]+)\s+netmask\s+([\d\.]+)/g);
 
     if ($#netandmasks % 2 == 0) {
-        $self->error("aii-dhcp: syntax error on dhcpd config file: " .
+        $self->error("AII::DHCP: syntax error on dhcpd config file: " .
                      "netmask/network missing in subnet declaration");
         return(1, '');
     }
@@ -189,7 +189,7 @@ sub update_dhcp_config_file
                 ST_NET  => $netandmasks[$i],
                 ST_MASK => $netandmasks[$i+1],
               });
-        $self->verbose("aii-dhcp: found subnet $netandmasks[$i] " .
+        $self->verbose("AII::DHCP: found subnet $netandmasks[$i] " .
                        "mask $netandmasks[$i+1]");
     }
 
@@ -237,10 +237,10 @@ sub update_dhcp_config_file
 
                 $newnodes .= "$indent}\n";
                 if ( $subnet_defined ) {
-                    $self->verbose("aii-dhcp: added node $node->{NAME} ".
+                    $self->verbose("AII::DHCP: added node $node->{NAME} ".
                                        "to subnet $net->{ST_NET}");
                 } else {
-                    $self->verbose("aii-dhcp: added node $node->{NAME} (no subnet specified)");
+                    $self->verbose("AII::DHCP: added node $node->{NAME} (no subnet specified)");
                 }
             }
 
@@ -248,7 +248,7 @@ sub update_dhcp_config_file
 
         # Insert the nodes in the current subnet
         if ($newnodes ne '') {
-            $self->debug(1, "aii-dhcp: newnodes=|$newnodes|\n");
+            $self->debug(1, "AII::DHCP: newnodes=|$newnodes|\n");
             if ( $subnet_defined ) {
                 $text =~ s/( \s*  subnet  \s+ \Q$net->{ST_NET}\E  \s+
                          netmask \s+ \Q$net->{ST_MASK}\E \s+ \{
@@ -326,14 +326,14 @@ sub new_remove_entry
 
     # Check host
     if (!defined($host) || $host eq '') {
-        $self->warn('aii-dhcp: missing hostname');
+        $self->warn('AII::DHCP: missing hostname');
         return(1);
     }
 
     my ($fqdn, @all_address) = (gethostbyname($host))[0,4];
     if (! @all_address) {
         # The array is empty => invalid name
-        $self->warn("aii-dhcp: invalid hostname to remove ($host), DNS lookup failed");
+        $self->warn("AII::DHCP: invalid hostname to remove ($host), DNS lookup failed");
         return(1);
     }
 
@@ -345,7 +345,7 @@ sub new_remove_entry
             IP   => $ip,
          } );
 
-    $self->debug(2, "aii-dhcp: mark $host (fqdn: $fqdn, ip: $ip) to remove");
+    $self->debug(2, "AII::DHCP: mark $host (fqdn: $fqdn, ip: $ip) to remove");
 
     return(0);
 }
@@ -360,24 +360,24 @@ sub new_configure_entry
 
     # Check hostname
     if (!defined($host) || $host eq '') {
-        $self->warn('aii-dhcp: missing hostname');
+        $self->warn('AII::DHCP: missing hostname');
         return(1);
     }
 
     my ($fqdn, @all_address) = (gethostbyname($host))[0,4];
     if ($#all_address < 0) {        # The array is empty => invalid name
-        $self->warn("aii-dhcp: invalid hostname to add ($host)");
+        $self->warn("AII::DHCP: invalid hostname to add ($host)");
         return(1);
     }
 
     # Check MAC address
     if (!defined($mac)) {
-        $self->warn("aii-dhcp: missing MAC address for host $host");
+        $self->warn("AII::DHCP: missing MAC address for host $host");
         return(1);
     }
 
     if ($mac !~ /^([[:xdigit:]]{2}[\:\-]){5}[[:xdigit:]]{2}$/) {
-        $self->warn("aii-dhcp: MAC address $mac not valid for host $host");
+        $self->warn("AII::DHCP: MAC address $mac not valid for host $host");
         return(1);
     }
 
@@ -392,7 +392,7 @@ sub new_configure_entry
             $tftpserver = Socket::inet_ntoa($all_tftp_address[0]);
         } else {
             # The array is empty => invalid name
-            $self->warn("aii-dhcp: invalid TFTP server ($tftpserver) for $host: DNS lookup failed");
+            $self->warn("AII::DHCP: invalid TFTP server ($tftpserver) for $host: DNS lookup failed");
             return(1);
         }
     }
@@ -403,7 +403,7 @@ sub new_configure_entry
     # check if the host entry already exists
     foreach my $item (@{$self->{NTC}}) {
         if($item->{FQDN} eq $fqdn) {
-            $self->debug(2, "aii-dhcp: new MAC entry for existing host = $host fqdn = $fqdn mac = $mac");
+            $self->debug(2, "AII::DHCP: new MAC entry for existing host = $host fqdn = $fqdn mac = $mac");
             $item->{MAC} .= " $mac";
             $mac = ""; # flag meaning object found
             last;
@@ -421,8 +421,8 @@ sub new_configure_entry
                 ST_IP_TFTP => $tftpserver,
                 MORE_OPT   => $add_txt,
              } );
-        $self->debug(2, "aii-dhcp: add new entry: host = $host fqdn = $fqdn mac = $mac");
-        $self->debug(3, "aii-dhcp: add new entry: additional opts: $add_txt");
+        $self->debug(2, "AII::DHCP: add new entry: host = $host fqdn = $fqdn mac = $mac");
+        $self->debug(3, "AII::DHCP: add new entry: additional opts: $add_txt");
     }
 
     return(0);
@@ -461,11 +461,11 @@ sub read_input
         # get input data
         my $fh = CAF::FileReader->new($filename, log => $self);
         if ($EC->error()) {
-            $self->error("aii-dhcp: configurelist error: " .
+            $self->error("AII::DHCP: configurelist error: " .
                              "file access error $filename");
             $error +=1;
         } else {
-            $self->debug(2, "aii-dhcp: reading nodes to configure from file: $filename");
+            $self->debug(2, "AII::DHCP: reading nodes to configure from file: $filename");
             foreach my $item (split(m/\n/, "$fh")) {
                 if ($item =~ m/^\s*([^#].*?)\s*$/) {
                     $error += $self->new_configure_entry(split(m/\s+/, $1));
@@ -480,10 +480,10 @@ sub read_input
 
         my $fh = CAF::FileReader->new($filename, log => $self);
         if ($EC->error()) {
-            $self->error("aii-dhcp: removelist error: file access error $filename");
+            $self->error("AII::DHCP: removelist error: file access error $filename");
             $error +=1;
         } else {
-            $self->debug(2, "aii-dhcp: reading nodes to remove from file: $filename");
+            $self->debug(2, "AII::DHCP: reading nodes to remove from file: $filename");
             foreach my $item (split(m/\n/, "$fh")) {
                 if ($item =~ m/^\s*([^#].*?)\s*$/) {
                     $error += $self->new_remove_entry($1);
@@ -501,25 +501,25 @@ sub update_and_restart
     my $self = shift;
 
     my $filename = $self->option('dhcpconf');
-    $self->debug(1, "aii-dhcp: going to update dhcpd configuration $filename");
+    $self->debug(1, "AII::DHCP: going to update dhcpd configuration $filename if needed");
     my ($error, $changed) = $self->update_dhcp_config($filename);
     if ($error) {
-        $self->error("aii-dhcp: failed to update dhcpd configuration $filename");
+        $self->error("AII::DHCP: failed to update dhcpd configuration $filename");
         return;
     }
 
     # restart dhcpd daemon
-    if ($self->option('norestart')) {
-        $self->verbose("aii-dhcp: dhcpd daemon do not restart (norestart set)");
-    } else {
-        if ($changed) {
+    if ($changed) {
+        if ($self->option('norestart')) {
+            $self->verbose("AII::DHCP: config changed but norestart set!");
+        } else {
             my $cmd = $self->option('restartcmd');
-            $self->debug(1, "aii-dhcp: restarting dhcpd daemon using cmd '$cmd'");
+            $self->debug(1, "AII::DHCP: restarting dhcpd daemon using cmd '$cmd'");
             # expects an arayref
             $self->restart_daemon([split(/\s+/, $cmd)]);
-        } else {
-            $self->verbose("aii-dhcp: no changes to $filename: daemon not restarted");
-        }
+        } 
+    } else {
+        $self->verbose("AII::DHCP: no changes to $filename: daemon not restarted");
     }
     return 1;
 }
@@ -527,7 +527,7 @@ sub update_and_restart
 # return true if dhcp config need changes
 sub nodes_to_change {
     my $self = shift;
-    return  (scalar(@{$self->{NTC}}) > 0) || (scalar(@{$self->{NTR}}) > 0);
+    return  return (@{$self->{NTC}} + @{$self->{NTR}}) ? 1 : 0;
 }
 
 # return 1 on failure, 0 on success
@@ -536,14 +536,14 @@ sub configure
     my $self = shift;
 
     # process command line options
-    $self->debug(1, "aii-dhcp: reading cmd line or input files");
+    $self->debug(1, "AII::DHCP: reading cmd line or input files");
     if ($self->read_input()) {
-        $self->error("aii-dhcp: failed to process cmd line or input files");
+        $self->error("AII::DHCP: failed to process cmd line or input files");
         return(1);
     }
 
     # update dhcpd configuration file
-    if($self->nodes_to_change() ) {
+    if ($self->nodes_to_change()) {
 		return 1 if (!$self->update_and_restart()) ;
     } else {
         $self->debug(1, "aii-nbp: there are no changes to dhcpd configuration to make");

--- a/aii-core/src/main/perl/DHCP.pm
+++ b/aii-core/src/main/perl/DHCP.pm
@@ -116,7 +116,6 @@ sub _initialize {
     unless ($self->SUPER::_initialize(@_)) {
         return;
     }
-
     # start using log file (could be done later on instead)
     $self->set_report_logfile($self->{'LOG'});
 
@@ -498,11 +497,11 @@ sub read_input
 
 # update the dhcp config file and restart daemon
 sub update_and_restart {
-	my $self = @_;
+	my $self = shift;
 
     my $filename = $self->option('dhcpconf');
     $self->debug(1, "aii-dhcp: going to update dhcpd configuration $filename");
-    my ($error, $changed) = $self->update_dhcp_config();
+    my ($error, $changed) = $self->update_dhcp_config($filename);
     if ($error) {
         $self->error("aii-dhcp: failed to update dhcpd configuration $filename");
         return(1);
@@ -525,7 +524,7 @@ sub update_and_restart {
 
 # return true if dhcp config need changes
 sub nodes_to_change {
-    my $self = @_;
+    my $self = shift;
     return  (scalar(@{$self->{NTC}}) > 0) || (scalar(@{$self->{NTR}}) > 0);
 }
 

--- a/aii-core/src/main/perl/DHCP.pm
+++ b/aii-core/src/main/perl/DHCP.pm
@@ -496,15 +496,16 @@ sub read_input
 }
 
 # update the dhcp config file and restart daemon
-sub update_and_restart {
-	my $self = shift;
+sub update_and_restart 
+{
+    my $self = shift;
 
     my $filename = $self->option('dhcpconf');
     $self->debug(1, "aii-dhcp: going to update dhcpd configuration $filename");
     my ($error, $changed) = $self->update_dhcp_config($filename);
     if ($error) {
         $self->error("aii-dhcp: failed to update dhcpd configuration $filename");
-        return(1);
+        return;
     }
 
     # restart dhcpd daemon
@@ -520,6 +521,7 @@ sub update_and_restart {
             $self->verbose("aii-dhcp: no changes to $filename: daemon not restarted");
         }
     }
+    return 1;
 }
 
 # return true if dhcp config need changes
@@ -542,7 +544,7 @@ sub configure
 
     # update dhcpd configuration file
     if($self->nodes_to_change() ) {
-		$self->update_and_restart();
+		return 1 if (!$self->update_and_restart()) ;
     } else {
         $self->debug(1, "aii-nbp: there are no changes to dhcpd configuration to make");
     }

--- a/aii-core/src/main/perl/DHCP.pm
+++ b/aii-core/src/main/perl/DHCP.pm
@@ -530,6 +530,19 @@ sub nodes_to_change
     return  return (@{$self->{NTC}} + @{$self->{NTR}}) ? 1 : 0;
 }
 
+# update dhcpd configuration file
+sub configure_dhcp
+{
+    my $self = shift;
+    if ($self->nodes_to_change()) {
+        $self->info('DHCP will be updated and restarted if needed');
+        return 0 if (!$self->update_and_restart());
+    } else {
+        $self->debug(1, "AII:DHCP: DHCP up to date, no nodes to configure");
+    }
+    return 1;
+}
+
 # return 1 on failure, 0 on success
 sub configure
 {
@@ -541,13 +554,7 @@ sub configure
         $self->error("AII::DHCP: failed to process cmd line or input files");
         return(1);
     }
-
-    # update dhcpd configuration file
-    if ($self->nodes_to_change()) {
-        return 1 if (!$self->update_and_restart()) ;
-    } else {
-        $self->debug(1, "AII:DHCP: no nodes to configure, no changes to dhcp configuration");
-    }
+    return 1 if (!$self->configure_dhcp());
 
     return 0;
 }

--- a/aii-core/src/main/perl/Shellfe.pm
+++ b/aii-core/src/main/perl/Shellfe.pm
@@ -448,6 +448,9 @@ sub dhcp
             $self->debug (4, "Going to add dhcp entry of $node to remove");
             $ec = $mgr->new_remove_entry($node);
         }
+    } else {
+        $self->error('dhcp should only run for configure and remove methods');
+        $ec = 1;
     }
     if ($ec) {
         $self->error("Error when configuring $node");
@@ -700,7 +703,7 @@ sub init_pm
         );
         return $pm;
     } else {
-        return 0;
+        return;
     }
 }
     
@@ -710,7 +713,7 @@ foreach my $cmd (COMMANDS) {
     *{$cmd} = sub {
         my ($self, %node_states) = @_;
         my $method = "_$cmd";
-        my %responses = ();
+        my %responses; 
         my $pm = $self->init_pm($cmd, \%responses);
         foreach my $node (sort keys %node_states) {
             $self->debug (2, "$cmd: $node");
@@ -730,7 +733,7 @@ foreach my $cmd (COMMANDS) {
             my $res = { ec => $ec, method => $method, node => $node, mode => $pm ? 1 : 0 };
 
             if ($pm) {
-                $pm->finish($ec, $res ); # Terminates the child process
+                $pm->finish($ec, $res); # Terminates the child process
             } else {
                 $responses{$node} = $res;
             }

--- a/aii-core/src/main/perl/Shellfe.pm
+++ b/aii-core/src/main/perl/Shellfe.pm
@@ -873,7 +873,11 @@ sub check_protected {
 sub change_dhcp {
     my ($self, $method, %nodes) = @_;
 
-    my $dhcpmgr = AII::DHCP->new(log => $self);
+    my $dhcpmgr = AII::DHCP->new(
+        logfile => $self->option('logfile'), 
+        dhcpconf => $self->option('dhcpconf'), 
+        cfgfile => $self->option('cfgfile'), 
+        log => $self);
     foreach my $node (sort keys %nodes) {
         my $st = $nodes{$node};
         if ($st->{configuration}->elementExists(DHCPPATH)) {

--- a/aii-core/src/main/perl/Shellfe.pm
+++ b/aii-core/src/main/perl/Shellfe.pm
@@ -728,7 +728,7 @@ sub run_cmd {
             my $lock = $self->lock_node($node);
             if (! $lock) {
                 $self->error("aii-shellfe: couldn't acquire lock on $node for $cmd");
-            next;
+                next;
             };
         };
         $self->debug(5, "Going to start $cmd on node $node");
@@ -910,12 +910,8 @@ sub change_dhcp
             $self->dhcp($node, $st, $method, $dhcpmgr);
         }
     }    
-    if ($dhcpmgr->nodes_to_change()) {
-         $self->info('DHCP will be updated and restarted if needed');
-         $dhcpmgr->update_and_restart();
-    } else {
-        $self->debug(1, 'DHCP up to date, no nodes to configure');
-    }    
+    $dhcpmgr->configure_dhcp();
+
     return 1;
 }
       
@@ -1008,7 +1004,7 @@ sub cmds
                     $self->debug(5, "Method $cmd does not need dhcp");
                 }
             }
-            $self->info (scalar (keys (%nodes)) . " nodes to $cmd");
+            $self->verbose (scalar (keys (%nodes)) . " nodes to $cmd");
             $self->$cmd (%nodes);
             $self->info ("ran $cmd on ", scalar (keys (%nodes)), " nodes");
         }

--- a/aii-core/src/test/perl/dhcp.t
+++ b/aii-core/src/test/perl/dhcp.t
@@ -124,7 +124,6 @@ set_file_contents('/path/dhcpd.conf', $dhcpd);
 
 mkdir('target/test') if ! -d 'target/test';
 
-
 my $mod = AII::DHCP->new(@opts);
 ok(! $mod->configure(), 'configure returns success');
 

--- a/aii-core/src/test/perl/parallel.t
+++ b/aii-core/src/test/perl/parallel.t
@@ -1,0 +1,91 @@
+# -*- mode: cperl -*-
+
+use strict;
+use warnings;
+use CAF::Object;
+use Test::Deep;
+use Test::More;
+use Test::Quattor qw(basic);
+use Test::MockModule;
+use EDG::WP4::CCM::Element;
+use CAF::Application;
+use CAF::Reporter;
+use AII::Shellfe;
+
+use Readonly;
+
+$CAF::Object::NoAction = 1;
+
+my $caflock = Test::MockModule->new('CAF::Lock');
+my $cfg_basic = get_config_for_profile('basic');
+my $config_basic = { configuration => $cfg_basic };
+my %h = (
+    'test01.cluster' => $config_basic,
+    'test02.cluster' => $config_basic,
+    'test03.cluster' => $config_basic,
+    'test04.cluster' => $config_basic,
+);
+my $defres = {};
+foreach my $host (keys %h) {
+	$defres->{$host} = {
+    	'ec' => 0,
+    	'mode' => 0,
+    	'node' => $host,
+	};
+};
+
+$caflock->mock('set_lock', 1 );
+my @opts = qw(script --logfile=target/test/parallel.log --cfgfile=src/test/resources/parallel.cfg);
+
+
+
+my $mod = AII::Shellfe->new(@opts);
+
+my ($pm, %responses) = $mod->init_pm('test');
+ok(!$pm, 'parallel fork manager not initiated');
+
+
+foreach my $host (keys %h) {
+	$defres->{$host}->{method} = '_remove';
+};
+
+my $ok = $mod->remove(%h);
+cmp_deeply( $ok, $defres, 'correct result' ) ;
+
+$mod = AII::Shellfe->new(@opts, "--parallel", 2 );
+($pm, %responses) = $mod->init_pm('test');
+ok($pm, 'parallel fork manager initiated');
+
+foreach my $host (keys %h) {
+	$defres->{$host}->{mode} = 1;
+};
+$ok = $mod->remove(%h);
+cmp_deeply( $ok, $defres, 'correct result' ) ;
+
+foreach my $host (keys %h) {
+	$defres->{$host}->{method} = '_status';
+};
+$ok = $mod->status(%h);
+cmp_deeply( $ok, $defres, 'correct result' ) ;
+
+
+$mod = AII::Shellfe->new(@opts, "--parallel", 4 );
+($pm, %responses) = $mod->init_pm('test');
+ok($pm, 'parallel fork manager initiated');
+
+$ok = $mod->status(%h);
+cmp_deeply( $ok, $defres, 'correct result' ) ;
+
+foreach my $host (keys %h) {
+	$defres->{$host}->{method} = '_configure';
+};
+$ok = $mod->configure(%h);
+cmp_deeply( $ok, $defres, 'correct result' ) ;
+
+foreach my $host (keys %h) {
+	$defres->{$host}->{method} = '_install';
+};
+$ok = $mod->install(%h);
+cmp_deeply( $ok, $defres, 'correct result' ) ;
+
+done_testing();

--- a/aii-core/src/test/perl/shellfe-dhcp.t
+++ b/aii-core/src/test/perl/shellfe-dhcp.t
@@ -59,7 +59,7 @@ my %remove = (
 
 
 
-my @opts = qw(script --logfile=target/test/dhcp.log  --cfgfile=src/test/resources/dhcp.cfg);
+my @opts = qw(script --logfile=target/test/dhcp.log  --cfgfile=src/test/resources/shellfe.cfg --dhcpcfg=src/test/resources/dhcp.cfg);
 
 
 my $dhcpd = <<EOF;

--- a/aii-core/src/test/perl/shellfe-dhcp.t
+++ b/aii-core/src/test/perl/shellfe-dhcp.t
@@ -1,0 +1,152 @@
+# -*- mode: cperl -*-
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+use strict;
+use warnings;
+
+BEGIN {
+    use Socket;
+    *CORE::GLOBAL::gethostbyname = sub {
+        my $name = shift;
+        if ($name =~ m/host(\d+).example(\d+)?.com/) {
+            my $ip = "10.11.".(defined($2) ? $2+1 : 0).".$1";
+            return ($name, 1, 2, 3, inet_aton($ip)); # 5th element is packed network address
+        } else {
+            die("cannot lookup $name");
+        }
+    };
+}
+
+
+use CAF::Object;
+use Test::More;
+use Test::Quattor;
+use AII::DHCP;
+use AII::Shellfe;
+use Test::MockModule;
+use Test::Quattor qw(shellfe-dhcp-1 shellfe-dhcp-2 shellfe-dhcp-3 shellfe-dhcp-4 shellfe-dhcp-b);
+
+$CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
+
+my $mlock = Test::MockModule->new('CAF::Lock');
+my $lock = 0;
+$mlock->mock('set_lock', sub {$lock++; return 1;});
+
+
+my $cfg_1 = { configuration => get_config_for_profile('shellfe-dhcp-1') };
+my $cfg_2 = { configuration => get_config_for_profile('shellfe-dhcp-2') };
+my $cfg_3 = { configuration => get_config_for_profile('shellfe-dhcp-3') };
+my $cfg_4 = { configuration => get_config_for_profile('shellfe-dhcp-4') };
+my $cfg_b = { configuration => get_config_for_profile('shellfe-dhcp-b') };
+
+my %configure = ( 
+    'host1.example.com' => $cfg_1,
+    'host2.example.com' => $cfg_2,
+    'host3.example1.com' => $cfg_3,
+    'host4.example.com' => $cfg_4,
+);
+
+my %remove = (
+    'host1.example.com' => $cfg_1,
+    'host5.example.com' => $cfg_b,
+    'host6.example1.com' => $cfg_b,
+);
+
+
+
+
+
+my @opts = qw(script --logfile=target/test/dhcp.log  --cfgfile=src/test/resources/dhcp.cfg);
+
+
+my $dhcpd = <<EOF;
+
+subnet 10.11.0.0 netmask 255.255.255.0 {
+  host host100.example.com {
+    hardware ethernet 00:11:22:33:44:aa;
+    fixed-address 10.11.0.100;
+    next-server 10.11.0.0;
+  }
+
+  host host5.example.com {  # added by aii-dhcp
+    hardware ethernet 00:11:22:33:44:cc;
+    fixed-address 10.11.0.5;
+    next-server 10.11.0.0;
+    if () { evenmore } else {whatever};
+  }
+
+}
+
+subnet 10.11.2.0 netmask 255.255.255.0 {
+  host host6.example1.com {  # added by aii-dhcp
+      hardware ethernet 00:11:22:33:44:bb;
+  }
+}
+
+EOF
+
+
+my $new_dhcpd = <<EOF;
+
+subnet 10.11.0.0 netmask 255.255.255.0 {
+  host host100.example.com {
+    hardware ethernet 00:11:22:33:44:aa;
+    fixed-address 10.11.0.100;
+    next-server 10.11.0.0;
+  }
+
+
+  host host1.example.com {  # added by aii-dhcp
+    hardware ethernet 00:11:22:33:44:55;
+    fixed-address 10.11.0.1;
+    next-server 10.11.0.0;
+    moremore
+  }
+
+  host host2.example.com {  # added by aii-dhcp
+    hardware ethernet 00:11:22:33:44:66;
+    fixed-address 10.11.0.2;
+    next-server 10.11.0.0;
+  }
+
+  host host4.example.com {  # added by aii-dhcp
+    hardware ethernet 00:11:22:33:44:99;
+    fixed-address 10.11.0.4;
+    next-server 10.11.0.0;
+    evenmore
+  }
+}
+
+subnet 10.11.2.0 netmask 255.255.255.0 {
+
+  host host3.example1.com {  # added by aii-dhcp
+    hardware ethernet 00:11:22:33:44:88;
+    fixed-address 10.11.2.3;
+  }
+}
+
+EOF
+
+# set via dhcp.cfg
+set_file_contents('/path/dhcpd.conf', $dhcpd);
+
+mkdir('target/test') if ! -d 'target/test';
+
+my $mod = AII::Shellfe->new(@opts);
+
+my $rem = $mod->change_dhcp('Unconfigure', %remove);
+my $con = $mod->change_dhcp('Configure', %configure);
+ok ($rem, 'remove returns success');
+ok ($con, 'configure returns success');
+
+is($lock, 2, "lock taken twice");
+
+ok(get_command('/sbin/service dhcpd restart'), 'dhcpd restarted');
+
+my $fh = get_file('/path/dhcpd.conf');
+is("$fh", $new_dhcpd, "generated new config file");
+
+done_testing();

--- a/aii-core/src/test/resources/dhcp.cfg
+++ b/aii-core/src/test/resources/dhcp.cfg
@@ -1,1 +1,2 @@
 dhcpconf = /path/dhcpd.conf
+logfile = target/test/dhcp.log

--- a/aii-core/src/test/resources/parallel.cfg
+++ b/aii-core/src/test/resources/parallel.cfg
@@ -1,0 +1,2 @@
+# intentionaly left empty
+

--- a/aii-core/src/test/resources/shellfe-dhcp-1.pan
+++ b/aii-core/src/test/resources/shellfe-dhcp-1.pan
@@ -1,0 +1,9 @@
+object template shellfe-dhcp-1;
+
+include 'shellfe-dhcp';
+
+"/system/aii/dhcp/options/tftpserver" = 'host0.example.com';
+"/system/aii/dhcp/options/addoptions" = 'moremore';
+
+"/hardware/cards/nic/eth0/hwaddr" = "00:11:22:33:44:55";
+

--- a/aii-core/src/test/resources/shellfe-dhcp-2.pan
+++ b/aii-core/src/test/resources/shellfe-dhcp-2.pan
@@ -1,0 +1,8 @@
+object template shellfe-dhcp-2;
+
+include 'shellfe-dhcp';
+
+"/system/aii/dhcp/options/tftpserver" = 'host0.example.com';
+
+"/hardware/cards/nic/eth0/hwaddr" = "00:11:22:33:44:66";
+

--- a/aii-core/src/test/resources/shellfe-dhcp-3.pan
+++ b/aii-core/src/test/resources/shellfe-dhcp-3.pan
@@ -1,0 +1,5 @@
+object template shellfe-dhcp-3;
+
+include 'shellfe-dhcp';
+
+"/hardware/cards/nic/eth0/hwaddr" = "00:11:22:33:44:88";

--- a/aii-core/src/test/resources/shellfe-dhcp-4.pan
+++ b/aii-core/src/test/resources/shellfe-dhcp-4.pan
@@ -1,0 +1,9 @@
+object template shellfe-dhcp-4;
+
+include 'shellfe-dhcp';
+
+"/system/aii/dhcp/options/tftpserver" = 'host0.example.com';
+"/system/aii/dhcp/options/addoptions" = 'evenmore';
+
+"/hardware/cards/nic/eth0/hwaddr" = "00:11:22:33:44:99";
+

--- a/aii-core/src/test/resources/shellfe-dhcp-b.pan
+++ b/aii-core/src/test/resources/shellfe-dhcp-b.pan
@@ -1,0 +1,7 @@
+object template shellfe-dhcp-b;
+
+include 'shellfe-dhcp';
+
+
+"/hardware/cards/nic/eth0/hwaddr" = "00:11:22:33:44:cc";
+

--- a/aii-core/src/test/resources/shellfe-dhcp.pan
+++ b/aii-core/src/test/resources/shellfe-dhcp.pan
@@ -1,0 +1,14 @@
+unique template shellfe-dhcp;
+
+"/system/aii/dhcp/options" = dict();
+
+"/hardware/cards/nic/eth0" = dict(
+    "boot", true,
+    "driver", "bnx2",
+#    "hwaddr", "AA:01:00:80:04:04",
+    "maxspeed", 1000,
+    "media", "Ethernet",
+    "name", "Broadcom NetXtreme II",
+    "pxe", true,
+);
+


### PR DESCRIPTION
Enabling parallelism reduces number of daemon restarts and hence reduces time taken to apply changes.

- Adds an option to run part of the code in parallel: the plugins except for dhcp. 
- DHCP changes are now gathered using the AII::DHCP module instead of calling aii-dhcp. 
- DHCP is now started twice at most (in remove and configure phase) . This is done BEFORE the remove and configure (earlier this was done after other plugins for remove cmd)
- Unused options `restartcmd` and `dhcpconf` were removed. A new option `dhcpcfg` is provided, which makes it possible to overwrite the config file for AII::DHCP module
- Requires Perl > 5.10.1 — effectively removing support for EL5.
- Fixes #241