### PR TITLE
aii-ks: relax test regexp due to fp rounding issues

### DIFF
--- a/aii-ks/src/test/resources/regexps/pre_blocksize_blockdevices
+++ b/aii-ks/src/test/resources/regexps/pre_blocksize_blockdevices
@@ -1,7 +1,7 @@
 Test the blockdevice generation in the pre section with disk with correct size defined
 ---
 ---
-^correct_disksize_MiB /dev/sdb 3996 4004$
+^correct_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
 ^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
@@ -28,7 +28,7 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^$
 ^\s{4}echo /dev/sdb1 >> /tmp/created_partitions$
 ^fi$
-^correct_disksize_MiB /dev/sdb 3996 4004$
+^correct_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
 ^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
@@ -55,7 +55,7 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^$
 ^\s{4}echo /dev/sdb2 >> /tmp/created_partitions$
 ^fi$
-^correct_disksize_MiB /dev/sdb 3996 4004$
+^correct_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
 ^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
@@ -82,7 +82,7 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^$
 ^\s{4}echo /dev/sdb3 >> /tmp/created_partitions$
 ^fi$
-^correct_disksize_MiB /dev/sdb 3996 4004$
+^correct_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
 ^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
@@ -111,7 +111,7 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^fi$
 ^lvm vgscan --mknodes$
 ^lvm vgchange -ay$
-^correct_disksize_MiB /dev/sdb 3996 4004$
+^correct_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
 ^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$


### PR DESCRIPTION
Reported during #225 

Tests fail due to `checksize` kickstart code not matching the regexps

Produced kickstart output (incl reporting)
 * the VERB lines are from ncm-lib-blockdevices
 * the value printed in the pre section is floored first, but shouldn't change between perl versions.
```
# 
# [VERB] Going to use 2 conditions: diff, fraction
# [VERB] Diff defined 100, updated min/max 3900 / 4100
# [VERB] Fraction defined 0.001, updated min/max 3996 / 4004
# correct_disksize_MiB /dev/sdb 3996 4003
```

the issue is the following floating rounding:
```
$  perl -e 'use POSIX qw(floor);$a=(1+0.001)*4000;printf("%d %.30f %d\n", $a, $a, floor($a));'
4003 4003.999999999999545252649113535881 4003
```
