### PR TITLE
aii-ks: rename ncm-lib-blockdevices 'correct' to 'validate'

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -783,7 +783,7 @@ disksize_MiB () {
     return $RET
 }
 
-correct_disksize_MiB () {
+valid_disksize_MiB () {
     # takes 3 args: device path, minimum size and maximum size
     # uses exitcode for result (e.g. if [ $? -ne 0 ] to test for failure)
     local path min max SIZE RET

--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -2,7 +2,7 @@
 
 use EDG::WP4::CCM::Path qw (escape unescape);
 use NCM::Filesystem;
-use NCM::Partition qw (partition_compare);
+use NCM::Partition 16.12.1 qw (partition_sort);
 use NCM::BlockdevFactory qw (build);
 
 use LC::Exception qw (throw_error);
@@ -940,8 +940,9 @@ sub ksprint_filesystems
         push (@part, $pt);
     }
     # Partitions go first, as of bug #26137
-    $_->create_pre_ks foreach (sort partition_compare @part);
-    foreach (sort partition_compare @part) {
+    $_->create_pre_ks foreach (partition_sort(@part));
+
+    foreach (partition_sort(@part)) {
         $_->align_ks if $_->can('align_ks');
     }
     $_->create_ks foreach @filesystems;

--- a/aii-ks/src/test/resources/kickstart_pre_blocksize.pan
+++ b/aii-ks/src/test/resources/kickstart_pre_blocksize.pan
@@ -8,6 +8,6 @@ include 'kickstart';
 
 include 'blockdevices';
 
-"/system/blockdevices/physical_devs/sdb/correct/size/fraction" = 0.001;
-"/system/blockdevices/physical_devs/sdb/correct/size/diff" = 100;
+"/system/blockdevices/physical_devs/sdb/validate/size/fraction" = 0.001;
+"/system/blockdevices/physical_devs/sdb/validate/size/diff" = 100;
 

--- a/aii-ks/src/test/resources/regexps/pre_blocksize_blockdevices
+++ b/aii-ks/src/test/resources/regexps/pre_blocksize_blockdevices
@@ -1,9 +1,9 @@
-Test the blockdevice generation in the pre section with disk with correct size defined
+Test the blockdevice generation in the pre section with disk with valid size defined
 ---
 ---
-^correct_disksize_MiB /dev/sdb 3996 400[34]$
+^valid_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
-^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
+^\s{4}echo "\[ERROR\] Invalid size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
 ^fi$
 ^if ! grep -q 'sdb1\$' /proc/partitions$
@@ -28,9 +28,9 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^$
 ^\s{4}echo /dev/sdb1 >> /tmp/created_partitions$
 ^fi$
-^correct_disksize_MiB /dev/sdb 3996 400[34]$
+^valid_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
-^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
+^\s{4}echo "\[ERROR\] Invalid size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
 ^fi$
 ^if ! grep -q 'sdb2\$' /proc/partitions$
@@ -55,9 +55,9 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^$
 ^\s{4}echo /dev/sdb2 >> /tmp/created_partitions$
 ^fi$
-^correct_disksize_MiB /dev/sdb 3996 400[34]$
+^valid_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
-^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
+^\s{4}echo "\[ERROR\] Invalid size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
 ^fi$
 ^if ! grep -q 'sdb3\$' /proc/partitions$
@@ -82,9 +82,9 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^$
 ^\s{4}echo /dev/sdb3 >> /tmp/created_partitions$
 ^fi$
-^correct_disksize_MiB /dev/sdb 3996 400[34]$
+^valid_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
-^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
+^\s{4}echo "\[ERROR\] Invalid size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
 ^fi$
 ^if ! grep -q 'sdb4\$' /proc/partitions$
@@ -111,9 +111,9 @@ Test the blockdevice generation in the pre section with disk with correct size d
 ^fi$
 ^lvm vgscan --mknodes$
 ^lvm vgchange -ay$
-^correct_disksize_MiB /dev/sdb 3996 400[34]$
+^valid_disksize_MiB /dev/sdb 3996 400[34]$
 ^if \[ \$\? -ne 0 \]; then$
-^\s{4}echo "\[ERROR\] Incorrect size for /dev/sdb. Exiting pre with exitcode 1."$
+^\s{4}echo "\[ERROR\] Invalid size for /dev/sdb. Exiting pre with exitcode 1."$
 ^\s{4}exit 1$
 ^fi$
 ^grep -q '/dev/sdb1\$' /tmp/created_partitions && mkfs.ext3 /dev/sdb1$

--- a/aii-ks/src/test/resources/regexps/pre_noblock_functions
+++ b/aii-ks/src/test/resources/regexps/pre_noblock_functions
@@ -64,7 +64,7 @@ Test the functions in the pre section
 ^\s{4}return \$RET$
 ^\}$
 ^$
-^correct_disksize_MiB \(\) \{$
+^valid_disksize_MiB \(\) \{$
 ^\s{4}\# takes 3 args: device path, minimum size and maximum size$
 ^\s{4}\# uses exitcode for result \(e.g. if \[ \$\? -ne 0 \] to test for failure\)$
 ^\s{4}local path min max SIZE RET$


### PR DESCRIPTION
Related to renaming done in https://github.com/quattor/template-library-core/pull/139 and https://github.com/quattor/ncm-lib-blockdevices/pull/79
Requires https://github.com/quattor/ncm-lib-blockdevices/pull/80