### PR TITLE
aii-ks: xwindows: depth and resolution are not supported in EL6+

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -20,10 +20,10 @@ type structure_ks_ksxinfo = {
     "vsync"		? long
     "hsync"		? long
     "defaultdesktop" : string with match (SELF, "^(GNOME|KDE)$")
-    "resolution"	: string with match (SELF, "^[0-9]+x[0-9]+$")
+    "resolution"	? string with {deprecated(0, "resolution unsupported in EL6+"); match(SELF, '^\d+x\d+$');}
     "videoram"	? long
     "startxonboot"	: boolean = true
-    "depth"		: long (1..32) = 24
+    "depth"		? long (1..32) with {deprecated(0, "depth unsupported in EL6+"); true;}
 };
 
 type string_ksservice = string with match (SELF, "^(ssh|telnet|smtp|http|ftp)$");

--- a/aii-ks/src/main/pan/quattor/aii/ks/variants/sl5.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/variants/sl5.pan
@@ -1,0 +1,12 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+# Template containing OS configuration and default values.
+
+template quattor/aii/ks/variants/sl5;
+
+prefix "/system/aii/osinstall/ks";
+# previous default value for mandatory schema entry
+"xwindows/depth" ?= 24;


### PR DESCRIPTION
Fixes #262
Backwards incompatible for EL5 setups that do not match variant name `sl5`