### PR TITLE
Allow LOCALHOST in a ksuserscript URL to substituted.

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -566,6 +566,7 @@ sub ksuserscript
 
     return unless $config->elementExists ($path);
     my $url = $config->getElement ($path)->getValue;
+    $url =~ s{LOCALHOST}{LOCALHOST}e;
     $this_app->debug (5, "User defined script to be fetched ",
                       "from $url for path $path");
 

--- a/aii-ks/src/main/perl/ks.pod
+++ b/aii-ks/src/main/perl/ks.pod
@@ -131,6 +131,8 @@ installation.
 URLs where the user-specific scripts can be fetched from. Please note
 that these scripts are not hooks!
 
+LOCALHOST will be substituted with the local hostname.
+
 =item * timezone : string
 
 Your local timezone, e.g: Europe/Madrid.


### PR DESCRIPTION
As is done in aii-pxelinux, so the file can be served by the host
generating the kickstart.