### PR TITLE
ks: set useexisting_lv flag for el7

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -2,8 +2,8 @@
 
 use EDG::WP4::CCM::Path qw (escape unescape);
 use NCM::Filesystem;
-use NCM::Partition 16.12.1 qw (partition_sort);
-use NCM::BlockdevFactory qw (build);
+use NCM::Partition qw (partition_sort);
+use NCM::BlockdevFactory 18.3.1 qw (build);
 
 use LC::Exception qw (throw_error);
 use CAF::FileWriter;
@@ -579,6 +579,7 @@ EOF
         }
         if ($version >= ANACONDA_VERSION_EL_7_0) {
              $fstree->{useexisting_md} = 1;
+             $fstree->{useexisting_lv} = 1;
         }
 
         $fstree->print_ks;

--- a/aii-ks/src/test/perl/kickstart_mounts.t
+++ b/aii-ks/src/test/perl/kickstart_mounts.t
@@ -16,7 +16,9 @@ Tests for the C<ksmountpoints> method.
 
 $CAF::Object::NoAction = 1;
 
-my $fh = CAF::FileWriter->new("target/test/ks");
+my $tdir = "target/test";
+mkdir($tdir) if ! -d $tdir;
+my $fh = CAF::FileWriter->new("$tdir/ks");
 # This module simply prints to the default filehandle.
 select($fh);
 
@@ -24,10 +26,13 @@ my $ks = NCM::Component::ks->new('ks');
 my $cfg = get_config_for_profile('kickstart_mounts');
 
 NCM::Component::ks::ksmountpoints($cfg);
+diag "ks $fh";
+
 like($fh, qr{^part swap --onpart sdb1 --fstype=swap --fsoptions='auto'\s$}m, 'swap part ok for el7');
 unlike ($fh, qr{sdb1.*--noformat}m, 'swap part has no noformat option');
 unlike ($fh, qr{(oddfs|mapper)}m, 'mapper/oddfs have aii=false flag');
 like($fh, qr{raid /boot --device=md1 --noformat --useexisting}m, 'raid with el7 uses useexisting');
+like($fh, qr{logvol /evenfs --vgname=vg0 --name=lv0 --noformat --useexisting}m, 'logvol with el7 uses useexisting');
 # close the selected FH and reset STDOUT
 NCM::Component::ks::ksclose;
 

--- a/aii-ks/src/test/resources/kickstart_mounts.pan
+++ b/aii-ks/src/test/resources/kickstart_mounts.pan
@@ -24,6 +24,11 @@ prefix "/system/aii/osinstall/ks";
             "size", 100,
             "type", "primary", # no defaults !
         ),
+        "sdb2", dict(
+            "holding_dev", "sdb",
+            "size", 100,
+            "type", "primary", # no defaults !
+        ),
         escape("mapper/special1"), dict(
             "holding_dev", escape("mapper/special"),
             "type", "primary",
@@ -37,7 +42,17 @@ prefix "/system/aii/osinstall/ks";
             "stripe_size", 64,
             ),
     ),
-
+    "volume_groups", dict(
+        "vg0", dict (
+            "device_list", list ("partitions/sdb2"),
+            )
+        ),
+    "logical_volumes", dict(
+        "lv0", dict (
+            "size", 800,
+            "volume_group", "vg0"
+            ),
+        ),
 );
 
 "/system/filesystems" = list (
@@ -71,6 +86,17 @@ prefix "/system/aii/osinstall/ks";
         "mountopts", "auto",
         "block_device", escape("mapper/special1"),
         "aii", false,
+        "type", "ext4",
+        "freq", 0,
+        "pass", 1
+    ),
+    dict(
+        "mount", true,
+        "mountpoint", "/evenfs",
+        "preserve", true,
+        "format", false,
+        "mountopts", "auto",
+        "block_device", "logical_volumes/lv0",
         "type", "ext4",
         "freq", 0,
         "pass", 1


### PR DESCRIPTION
Requires quattor/ncm-lib-blockdevices#88