### PR TITLE
ks: support leavebootorder option

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -134,4 +134,5 @@ type structure_ks_ks_info = {
     'bonding' ? boolean
     'lvmforce' ? boolean
     'init_spma_ignore_deps' ? boolean
+    'leavebootorder' ? boolean
 };

--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -449,6 +449,9 @@ EOF
         if $tree->{bootloader_append};
     print " --password=\"$tree->{bootloader_password}\" --iscrypted"
         if $tree->{bootloader_password};
+    if ($tree->{leavebootorder} && $version >= ANACONDA_VERSION_EL_7_0) {
+        print " --leavebootorder";
+    }
     print "\n";
 
     if ($tree->{xwindows}) {


### PR DESCRIPTION
The default feature for anaconda is to change the boot order on systems that support it, for ordinary systems this is desirable, but is a problem for automated management systems like Quattor which rely on the system to always boot from network and fall back to localboot if no boot-time action (i.e. re-install) is required.

This adds support for the Anaconda option which disables the modifcation of boot order.