### PR TITLE
aii-core: add perl-IPC-Run as a required dependency

### DIFF
--- a/aii-core/pom.xml
+++ b/aii-core/pom.xml
@@ -217,6 +217,7 @@
             <url>https://github.com/quattor/aii/tree/master/aii-core</url>
             <requires>
               <require>perl-CDB_File</require>
+              <require>perl-IPC-Run</require>
               <require>perl-XML-Simple</require>
             </requires>
             <mappings>


### PR DESCRIPTION
- Required by aii-installfe

Fixes #288