### PR TITLE
ks.pm: do not redirect to /dev/null dd erros

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -853,8 +853,8 @@ wipe_metadata () {
     fi
     echo "[INFO] wipe path $path with SIZE $SIZE and ENDSEEK $ENDSEEK"
     # dd with 1 MiB blocksize (unit used by disksize_MiB and faster then e.g. bs=512)
-    dd if=/dev/zero of="$path" bs=1048576 count=$ENDSEEK_OFFSET 2>/dev/null
-    dd if=/dev/zero of="$path" bs=1048576 seek=$ENDSEEK 2>/dev/null
+    dd if=/dev/zero of="$path" bs=1048576 count=$ENDSEEK_OFFSET
+    dd if=/dev/zero of="$path" bs=1048576 seek=$ENDSEEK
     sync
 }
 

--- a/aii-ks/src/test/resources/regexps/pre_noblock_functions
+++ b/aii-ks/src/test/resources/regexps/pre_noblock_functions
@@ -117,7 +117,7 @@ Test the functions in the pre section
 ^\s{4}fi$
 ^\s{4}echo "\[INFO\] wipe path \$path with SIZE \$SIZE and ENDSEEK \$ENDSEEK"$
 ^\s{4}\# dd with 1 MiB blocksize \(unit used by disksize_MiB and faster then e.g. bs=512\)$
-^\s{4}dd if=/dev/zero of="\$path" bs=1048576 count=\$ENDSEEK_OFFSET 2>/dev/null$
-^\s{4}dd if=/dev/zero of="\$path" bs=1048576 seek=\$ENDSEEK 2>/dev/null$
+^\s{4}dd if=/dev/zero of="\$path" bs=1048576 count=\$ENDSEEK_OFFSET$
+^\s{4}dd if=/dev/zero of="\$path" bs=1048576 seek=\$ENDSEEK$
 ^\s{4}sync$
 ^\}$


### PR DESCRIPTION
- dd errors may be useful to troubleshoot partition wiping