### PR TITLE
aii-ks: Do not define ackurl if it is not needed

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/config.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/config.pan
@@ -379,12 +379,23 @@ variable AII_OSINSTALL_PACKAGES ?= list(
 # If is not true, the following variables should be set to define the PXE server:
 #    AII_ACK_SRV : the name of the PXE server
 #    AII_ACK_CGI : the location of the acknowledgement script to end the installation
+#    AII_ACK_LIST: list of URLs to try if the acknowledgement needs to be sent
+#                  to multiple servers. If AII_ACK_LIST is set, then AII_ACK_SRV and
+#                  AII_ACK_CGI are not used here.
 #
 # If the variables are undefined, the defaults are set below.
 #
 variable AII_ACK_SRV ?= AII_OSINSTALL_SRV;
 variable AII_ACK_CGI ?= "/cgi-bin/aii-installack.cgi";
-"ackurl" = "http://" + AII_ACK_SRV + AII_ACK_CGI;
+variable AII_ACK_LIST ?= null;
+"acklist" = AII_ACK_LIST;
+"ackurl" = {
+    if (!is_defined(value("/system/aii/osinstall/ks/acklist"))) {
+        "http://" + AII_ACK_SRV + AII_ACK_CGI;
+    } else {
+        null;
+    };
+};
 
 
 #

--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -75,7 +75,7 @@ type structure_ks_mail = {
     for user customization are under /system/ks/hooks/.
 }
 type structure_ks_ks_info = {
-    "ackurl" : type_absoluteURI
+    "ackurl" ? type_absoluteURI
     "acklist" ? type_absoluteURI[]
     "auth" : string[] = list ("enableshadow", "passalgo=sha512")
     "bootloader_location" : string = "mbr"


### PR DESCRIPTION
Since the Perl code ignores ackurl if acklist is defined, it does not
make sense to force populating ackurl in templates.