### PR TITLE
aii-pxelinux: Give up regex-based interface name validation

### DIFF
--- a/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
+++ b/aii-pxelinux/src/main/pan/quattor/aii/pxelinux/schema.pan
@@ -13,10 +13,7 @@ include 'pan/types';
 type structure_pxelinux_pxe_info = {
     "initrd" : string
     "kernel" : string
-    "ksdevice" : string with match (SELF, ('^(bootif|link|' +
-        '(eth|seth|em|bond|br|vlan|usb|ib|p\d+p|' +
-        'en(o|(p\d+)?s(?:\d+f)?(?:\d+d)?)' +
-        ')\d+(\.\d+)?|enx\p{XDigit}{12})$')) || is_hwaddr (SELF)
+    "ksdevice"  : string with match(SELF, '^(bootif|link)$') || is_hwaddr(SELF) || exists("/system/network/interfaces/" + escape(SELF))
     "kslocation" : type_absoluteURI
     "label"  : string
     "append" ? string

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_1.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_1.pan
@@ -2,5 +2,7 @@ object template pxelinux_ks_ksdevice_systemd_scheme_1;
 
 include 'pxelinux_ks';
 
+"/system/network/interfaces/{eno1}" = value("/system/network/interfaces/{eth0}");
+
 prefix "/system/aii/nbp/pxelinux";
 "ksdevice" = "eno1";

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_2.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_2.pan
@@ -2,5 +2,7 @@ object template pxelinux_ks_ksdevice_systemd_scheme_2;
 
 include 'pxelinux_ks';
 
+"/system/network/interfaces/{ens1}" = value("/system/network/interfaces/{eth0}");
+
 prefix "/system/aii/nbp/pxelinux";
 "ksdevice" = "ens1";

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_3.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_3.pan
@@ -2,5 +2,7 @@ object template pxelinux_ks_ksdevice_systemd_scheme_3;
 
 include 'pxelinux_ks';
 
+"/system/network/interfaces/{enp2s0}" = value("/system/network/interfaces/{eth0}");
+
 prefix "/system/aii/nbp/pxelinux";
 "ksdevice" = "enp2s0";

--- a/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_4.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_ks_ksdevice_systemd_scheme_4.pan
@@ -2,5 +2,7 @@ object template pxelinux_ks_ksdevice_systemd_scheme_4;
 
 include 'pxelinux_ks';
 
+"/system/network/interfaces/{enx78e7d1ea46da}" = value("/system/network/interfaces/{eth0}");
+
 prefix "/system/aii/nbp/pxelinux";
 "ksdevice" = "enx78e7d1ea46da";


### PR DESCRIPTION
The regex become way too complex, and it interacts badly with custom
interface names. If the value of "ksdevice" is not one of the special
values understood by Anaconda, then it should rather be an existing
interface.