### PR TITLE
aii-ks: Offline update service tweaks

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -1671,9 +1671,13 @@ ExecStart=/etc/rc.d/init.d/ks-post-reboot start
 ExecStop=/bin/true
 ExecStopPost=/usr/bin/rm -fv /system-update
 FailureAction=reboot
-TimeoutSec=7200
+TimeoutSec=18000
 KillMode=control-group
 KillSignal=SIGKILL
+StandardInput=tty
+TTYPath=/dev/console
+TTYReset=yes
+TTYVHangup=yes
 EOF_reboot_unit
 
     # /system-update is expected to be a symlink, identifying which update script to run


### PR DESCRIPTION
Increase the timeout to 5 hours. Leave the standard input connected to
the console, to allow custom commands added by hooks to use the terminal
if they want.