### PR TITLE
aii-ks: Add a new hook for the "%post --nochroot" phase

### DIFF
--- a/aii-core/src/main/perl/aii-hooks.pod
+++ b/aii-core/src/main/perl/aii-hooks.pod
@@ -111,6 +111,12 @@ These hooks run at the end of the Kickstart directives section.
 
 These hooks are run after the partitioning code has been generated.
 
+=item C<post_install_nochroot> for C<%post --nochroot> phase hooks.
+
+These hooks are run outside of the sysinstall chroot, before the
+standard <%post> script actions, and e.g. allow copying data generated
+by earlier installer actions to the target image.
+
 =item C<post_install> for C<%post> phase hooks.
 
 These hooks are run before any kernel installations are done, on the
@@ -155,10 +161,10 @@ The following methods are exposed:
 
 Class constructor, without arguments.
 
-=item C<pre_install> C<post_install> C<post_reboot> C<install> C<boot>
-C<rescue> C<remove>
+=item C<pre_install> C<post_install_nochroot> C<post_install> C<post_reboot>
+C<install> C<boot> C<rescue> C<remove>
 
-For running pre_install, post_install and post_reboot actions on the
+For running pre_install, post_install_nochroot, post_install and post_reboot actions on the
 Kickstart, and install, boot, rescue or remove actions on the NBP
 configuration.
 

--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -34,6 +34,7 @@ use constant { KS               => "/system/aii/osinstall/ks",
                POSTREBOOTHOOK   => "/system/aii/hooks/post_reboot",
                POSTREBOOTENDHOOK        => "/system/aii/hooks/post_reboot_end",
                POSTSCRIPT       => "/system/aii/osinstall/ks/post_install_script",
+               POSTNOCHROOTHOOK => "/system/aii/hooks/post_install_nochroot",
                POSTHOOK         => "/system/aii/hooks/post_install",
                ANACONDAHOOK     => "/system/aii/hooks/anaconda",
                PREREBOOTHOOK    => "/system/aii/hooks/pre_reboot",
@@ -1581,6 +1582,11 @@ sub post_install_script
 %post --nochroot
 
 test -f /tmp/pre-log.log && cp -a /tmp/pre-log.log /mnt/sysimage/root/
+EOF
+
+    ksuserhooks ($config, POSTNOCHROOTHOOK);
+
+    print <<EOF;
 
 %end
 


### PR DESCRIPTION
This allows writing a plugin which opportunistically preserves content
(like SSH private host keys or Kerberos keytabs) by mounting the
previous filesystem(s) and copying files to the installer's ramdisk in
the pre_install phase, and restoring such saved files in the
post_install_nochroot phase.

Before RH7, it was possible to use the pre_install_end hook for
restoring such saved content to the newly formatted filesystem(s). But
Anaconda in RH7 wants to format the root filesystem itself, so restoring
the files now needs to happen later.