### PR TITLE
aii-ks: Deprecate ackurl

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/config.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/config.pan
@@ -387,16 +387,8 @@ variable AII_OSINSTALL_PACKAGES ?= list(
 #
 variable AII_ACK_SRV ?= AII_OSINSTALL_SRV;
 variable AII_ACK_CGI ?= "/cgi-bin/aii-installack.cgi";
-variable AII_ACK_LIST ?= null;
-"acklist" = AII_ACK_LIST;
-"ackurl" = {
-    if (!is_defined(value("/system/aii/osinstall/ks/acklist"))) {
-        "http://" + AII_ACK_SRV + AII_ACK_CGI;
-    } else {
-        null;
-    };
-};
-
+variable AII_ACK_LIST ?= list("http://" + AII_ACK_SRV + AII_ACK_CGI);
+"acklist" ?= AII_ACK_LIST;
 
 #
 # Set the location of the node profile

--- a/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/schema.pan
@@ -75,7 +75,7 @@ type structure_ks_mail = {
     for user customization are under /system/ks/hooks/.
 }
 type structure_ks_ks_info = {
-    "ackurl" ? type_absoluteURI
+    "ackurl" ? type_absoluteURI with {deprecated(0, "ackurl is deprecated, use acklist instead"); true; }
     "acklist" ? type_absoluteURI[]
     "auth" : string[] = list ("enableshadow", "passalgo=sha512")
     "bootloader_location" : string = "mbr"

--- a/aii-ks/src/main/perl/ks.pod
+++ b/aii-ks/src/main/perl/ks.pod
@@ -22,6 +22,8 @@ All these paths are relative to /system/aii/osinstall/ks.
 
 =item * ackurl : absolute URI
 
+Deprecated - use acklist instead.
+
 The absolute URL where the aii-installack.cgi script is located. This
 script will change the PXE state for the node from network boot
 ("install") to local boot ("boot"). This field is set automatically


### PR DESCRIPTION
Trying to support both ackurl and acklist is a bit awkward, and does not
have much benefits. Mark ackurl as deprecated. This should resolve #317.