### PR TITLE
aii-pxelinux: Fix UEFI boot over http

### DIFF
--- a/aii-core/src/main/perl/Shellfe.pm
+++ b/aii-core/src/main/perl/Shellfe.pm
@@ -371,6 +371,8 @@ sub _initialize
             $kernel_root = '' if ( $kernel_root eq '/' );
             $self->{CONFIG}->set(GRUB2_EFI_KERNEL_ROOT, $kernel_root);
         }
+    } else {
+        $self->{CONFIG}->set(GRUB2_EFI_KERNEL_ROOT, undef) if $self->option(GRUB2_EFI_KERNEL_ROOT) eq NBPDIR_VARIANT_DISABLED;
     }
     # GRUB2_EFI_INITRD_CMD is always derived from GRUB2_EFI_LINUX_CMD as
     # Grub2 has a set of linux/initrd command pairs that must match together.

--- a/aii-pxelinux/src/main/perl/pxelinux.pm
+++ b/aii-pxelinux/src/main/perl/pxelinux.pm
@@ -484,9 +484,17 @@ sub _write_grub2_config
         return 0;
     };
     my $kernel_root = $this_app->option(GRUB2_EFI_KERNEL_ROOT);
-    $kernel_root = '' unless defined($kernel_root);
-    my $kernel_path = "$kernel_root/$pxe_config->{kernel}";
-    my $initrd_path = "$kernel_root/$pxe_config->{initrd}";
+    my $prefix = defined($kernel_root) ? "$kernel_root/" : "";
+
+    # Avoid having an uncoditional "/" at the beginning, because that would
+    # break if the kernel/initrd location uses the "(http,XXXX)/..." or
+    # "(tftp,XXXX)/..." syntax
+    my ($kernel_path, $initrd_path);
+    $kernel_path = $pxe_config->{kernel} =~ m/^\((http|tftp),/ ? "" : $prefix;
+    $initrd_path = $pxe_config->{kernel} =~ m/^\((http|tftp),/ ? "" : $prefix;
+
+    $kernel_path .= $pxe_config->{kernel};
+    $initrd_path .= $pxe_config->{initrd};
 
     $kernel_path =~ s{\bLOCALHOST\b}{LOCALHOST}e;
     $initrd_path =~ s{\bLOCALHOST\b}{LOCALHOST}e;

--- a/aii-pxelinux/src/test/perl/write_grub2_config.t
+++ b/aii-pxelinux/src/test/perl/write_grub2_config.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Quattor qw(pxelinux_base_config);
+use Test::Quattor qw(pxelinux_base_config pxelinux_grub2);
 use NCM::Component::PXELINUX::constants qw(:pxe_variants :pxe_constants);
 use NCM::Component::pxelinux;
 use CAF::FileWriter;
@@ -40,12 +40,13 @@ sub check_config {
     # Check config file contents
     my $fh = get_file($fp);
     my $hostname = hostname();
+    my $prefix = $kernel_root ? "$kernel_root/" : "";
     like($fh, qr{^set default=0$}m, "default kernel ($test_msg)");
     like($fh, qr{^set timeout=\d+$}m, "Grub2 menu timeout ($test_msg)");
     like($fh, qr(^menuentry\s"Install\s[\w\-\s()\[\]]+"\s\{$)m, "Grub2 menu entry ($test_msg)");
     like($fh, qr{^\s{4}set root=\(pxe\)$}m, "Grub2 root ($test_msg)");
-    like($fh, qr{^\s{4}$TEST_EFI_LINUX_CMD $kernel_root/mykernel}m, "Kernel loading ($test_msg)");
-    like($fh, qr{^\s{4}$test_efi_initrd_cmd $kernel_root/path/to/initrd$}m, "initrd loading ($test_msg)");
+    like($fh, qr{^\s{4}$TEST_EFI_LINUX_CMD ${prefix}mykernel}m, "Kernel loading ($test_msg)");
+    like($fh, qr{^\s{4}$test_efi_initrd_cmd ${prefix}path/to/initrd$}m, "initrd loading ($test_msg)");
     like($fh, qr(^})m, "end of menu entry ($test_msg)");
 }
 
@@ -67,5 +68,10 @@ check_config($comp, $cfg, '', 'No GRUB2_EFI_KERNEL_ROOT');
 $this_app->{CONFIG}->define(GRUB2_EFI_KERNEL_ROOT);
 $this_app->{CONFIG}->set(GRUB2_EFI_KERNEL_ROOT, $GRUB2_EFI_KERNEL_ROOT_VALUE);
 check_config($comp, $cfg, $GRUB2_EFI_KERNEL_ROOT_VALUE, 'No GRUB2_EFI_KERNEL_ROOT');
+
+$cfg = get_config_for_profile('pxelinux_grub2');
+
+$this_app->{CONFIG}->set(GRUB2_EFI_KERNEL_ROOT, "/foo/bar");
+check_config($comp, $cfg, qr{\(http,myhost\.example\)}, 'Profile ignores GRUB2_EFI_KERNEL_ROOT');
 
 done_testing();

--- a/aii-pxelinux/src/test/resources/pxelinux_grub2.pan
+++ b/aii-pxelinux/src/test/resources/pxelinux_grub2.pan
@@ -1,0 +1,13 @@
+@{
+Grub2 object template for aii-pxelinux unit tests.
+Only include pxelinux_config.common.pan
+}
+
+object template pxelinux_grub2;
+
+include 'pxelinux_config_common';
+
+prefix "/system/aii/nbp/pxelinux";
+
+"kernel" = "(http,myhost.example)/mykernel";
+"initrd" = "(http,myhost.example)/path/to/initrd";


### PR DESCRIPTION
If the kernel/initrd specified in the profile uses the
"(http,XXXX)/path/to/image" syntax, then the extra slash which is
currently inserted unconditionally at the beginning causes Grub to fail.
Make sure a path separator is inserted only if GRUB2_EFI_KERNEL_ROOT is
in fact not empty.