### PR TITLE
aii-ks: Avoid spurious changes in the output

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -1440,10 +1440,11 @@ sub process_pkgs
 
     my @ret;
     if (%$ver) {
-        while (my ($version, $arch) = each(%$ver)) {
+        foreach my $version (sort keys %$ver) {
+            my $arch = $ver->{$version};
             my $p = sprintf("%s-%s", $pkg, unescape($version));
             if ($arch) {
-                push(@ret, map("$p.$_", keys(%{$arch->{arch}})));
+                push(@ret, map("$p.$_", sort keys(%{$arch->{arch}})));
             } else {
                 push(@ret, $p);
             }
@@ -1495,8 +1496,8 @@ sub simple_version_glob {
     };
 
     # add remainder unlocked non-matching packages
-    foreach my $ref (values %pkgs) {
-        push (@res, @$ref) ;
+    foreach my $key (sort keys %pkgs) {
+        push (@res, @{$pkgs{$key}}) ;
     };
     return @res;
 }


### PR DESCRIPTION
Recent Perl versions iterate over hashes in a random order. While this
does not directly affect functionality, the resulting random updates
to the generated Kickstart files make it difficult to spot real changes.
Add a few "sort" operators to make the output deterministic.