### PR TITLE
Use wipefs for RHEL6+

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -1,9 +1,9 @@
 #${PMpre} NCM::Component::ks${PMpost}
 
 use EDG::WP4::CCM::Path qw (escape unescape);
-use NCM::Filesystem 18.12.0;
+use NCM::Filesystem 19.12.1;
 use NCM::Partition qw (partition_sort);
-use NCM::BlockdevFactory 18.12.0 qw (build);
+use NCM::BlockdevFactory 19.12.1 qw (build);
 
 use LC::Exception qw (throw_error);
 use CAF::FileWriter;
@@ -804,21 +804,6 @@ EOF
     }
 
     print <<'EOF';
-
-# Hack for RHEL 6: force re-reading the partition table
-#
-# fdisk often fails to re-read the partition table on RHEL 6, so we have to do
-# it explicitely. We also have to make sure that udev had enough time to create
-# the device nodes.
-rereadpt () {
-    [ -x /sbin/udevadm ] && udevadm settle
-    # hdparm can still fail with EBUSY without the wait...
-    sleep 2
-    hdparm -q -z "$1"
-    [ -x /sbin/udevadm ] && udevadm settle
-    # Just in case...
-    sleep 2
-}
 
 disksize_MiB () {
     local path BYTES MB RET

--- a/aii-ks/src/test/resources/regexps/pre_noblock_functions
+++ b/aii-ks/src/test/resources/regexps/pre_noblock_functions
@@ -5,21 +5,6 @@ Test the functions in the pre section
 ^set -x$
 ^$
 ^$
-^\# Hack for RHEL 6: force re-reading the partition table$
-^\#$
-^\# fdisk often fails to re-read the partition table on RHEL 6, so we have to do$
-^\# it explicitely. We also have to make sure that udev had enough time to create$
-^\# the device nodes.$
-^rereadpt \(\) \{$
-^\s{4}\[ -x /sbin/udevadm \] && udevadm settle$
-^\s{4}\# hdparm can still fail with EBUSY without the wait...$
-^\s{4}sleep 2$
-^\s{4}hdparm -q -z "\$1"$
-^\s{4}\[ -x /sbin/udevadm \] && udevadm settle$
-^\s{4}\# Just in case...$
-^\s{4}sleep 2$
-^\}$
-^$
 ^disksize_MiB \(\) \{$
 ^\s{4}local path BYTES MB RET$
 ^\s{4}RET=0$

--- a/aii-ks/src/test/resources/regexps/pre_noblock_functions
+++ b/aii-ks/src/test/resources/regexps/pre_noblock_functions
@@ -47,36 +47,3 @@ Test the functions in the pre section
 ^\s{4}return \$RET$
 ^\}$
 ^$
-^wipe_metadata \(\) \{$
-^\s{4}local path clear SIZE ENDSEEK ENDSEEK_OFFSET$
-^\s{4}path="\$1"$
-^$
-^\s{4}# default to 1$
-^\s{4}clearmb="\$\{2:-1\}"$
-^$
-^\s{4}# wipe at least 4 MiB at begin and end$
-^\s{4}ENDSEEK_OFFSET=4$
-^\s{4}if \[ "\$clearmb" -gt \$ENDSEEK_OFFSET \]; then$
-^\s{8}ENDSEEK_OFFSET=\$clearmb$
-^\s{4}fi$
-^\s{4}\# try to get the size with fdisk$
-^\s{4}SIZE=`disksize_MiB "\$path"`$
-^$
-^\s{4}\# if empty, assume we failed and try with parted$
-^\s{4}if \[ \$SIZE -eq 0 \]; then$
-^\s{8}\# the SIZE has not been determined,$
-^\s{8}\# set it equal to ENDSEEK_OFFSET, the entire disk gets wiped.$
-^\s{8}SIZE=\$ENDSEEK_OFFSET$
-^\s{8}echo "\[WARN\] Could not determine the size of device \$path with both fdisk and parted. Wiping whole drive instead"$
-^\s{4}fi$
-^$
-^\s{4}let ENDSEEK=\$SIZE-\$ENDSEEK_OFFSET$
-^\s{4}if \[ \$ENDSEEK -lt 0 \]; then$
-^\s{8}ENDSEEK=0$
-^\s{4}fi$
-^\s{4}echo "\[INFO\] wipe path \$path with SIZE \$SIZE and ENDSEEK \$ENDSEEK"$
-^\s{4}\# dd with 1 MiB blocksize \(unit used by disksize_MiB and faster then e.g. bs=512\)$
-^\s{4}dd if=/dev/zero of="\$path" bs=1048576 count=\$ENDSEEK_OFFSET$
-^\s{4}dd if=/dev/zero of="\$path" bs=1048576 seek=\$ENDSEEK$
-^\s{4}sync$
-^\}$


### PR DESCRIPTION
Keep the previous custom wiping function for RHEL5 for a little longer.

This branch depends on https://github.com/quattor/ncm-lib-blockdevices/pull/93 due to removal of the `rereadpt` function.