### PR TITLE
aii-ks: Update regex tests to handle wipefs changes in ncm-lib-blockdevices

### DIFF
--- a/aii-ks/src/test/resources/regexps/pre_blocksize_blockdevices
+++ b/aii-ks/src/test/resources/regexps/pre_blocksize_blockdevices
@@ -29,10 +29,7 @@ Test the blockdevice generation in the pre section with disk with valid size def
 ^\s{4}fi$
 ^\s{4}end=\$\(\(begin \+ 100 \* \(1024 \* 1024 / sectsize\) - 1\)\)
 ^\s{4}parted /dev/sdb -s -- u s mkpart primary \$begin \$end$
-^\s{4}if \[ "primary" != "extended_no_msdos_label" \]$
-^\s{4}then$
-^\s{8}wipe_metadata /dev/sdb1 1$
-^\s{4}fi$
+^\s{4}wipe_metadata /dev/sdb1$
 ^\s{4}echo /dev/sdb1 >> /tmp/created_partitions$
 ^fi$
 ^valid_disksize_MiB /dev/sdb 3996 400[34]$
@@ -64,10 +61,7 @@ Test the blockdevice generation in the pre section with disk with valid size def
 ^\s{4}fi$
 ^\s{4}end=\$\(\(begin \+ 100 \* \(1024 \* 1024 / sectsize\) - 1\)\)
 ^\s{4}parted /dev/sdb -s -- u s mkpart primary \$begin \$end$
-^\s{4}if \[ "primary" != "extended_no_msdos_label" \]$
-^\s{4}then$
-^\s{8}wipe_metadata /dev/sdb2 1$
-^\s{4}fi$
+^\s{4}wipe_metadata /dev/sdb2$
 ^\s{4}echo /dev/sdb2 >> /tmp/created_partitions$
 ^fi$
 ^valid_disksize_MiB /dev/sdb 3996 400[34]$
@@ -98,10 +92,7 @@ Test the blockdevice generation in the pre section with disk with valid size def
 ^\s{4}fi$
 ^\s{4}end=\$\(\(begin \+ 2500 \* \(1024 \* 1024 / sectsize\) - 1\)\)
 ^\s{4}parted /dev/sdb -s -- u s mkpart extended \$begin \$end$
-^\s{4}if \[ "extended" != "extended_no_msdos_label" \]$
-^\s{4}then$
-^\s{8}wipe_metadata /dev/sdb3 1$
-^\s{4}fi$
+^\s{4}wipe_metadata /dev/sdb3$
 ^\s{4}echo /dev/sdb3 >> /tmp/created_partitions$
 ^fi$
 ^valid_disksize_MiB /dev/sdb 3996 400[34]$
@@ -132,10 +123,7 @@ Test the blockdevice generation in the pre section with disk with valid size def
 ^\s{4}fi$
 ^\s{4}end=\$\(\(begin \+ 1024 \* \(1024 \* 1024 / sectsize\) - 1\)\)
 ^\s{4}parted /dev/sdb -s -- u s mkpart logical \$begin \$end$
-^\s{4}if \[ "logical" != "extended_no_msdos_label" \]$
-^\s{4}then$
-^\s{8}wipe_metadata /dev/sdb4 1$
-^\s{4}fi$
+^\s{4}wipe_metadata /dev/sdb4$
 ^\s{4}echo /dev/sdb4 >> /tmp/created_partitions$
 ^fi$
 ^lvm vgscan --mknodes$


### PR DESCRIPTION
`wipe_metadata` is no longer conditional, nor does it take a size argument.

This was caused by the changes merged in quattor/ncm-lib-blockdevices@7ee1375ee8db9edda1b030d6de259a2d3eae2ae9.