### PR TITLE
aii-core: Binaries and Perl modules are not documentation

### DIFF
--- a/aii-core/pom.xml
+++ b/aii-core/pom.xml
@@ -223,6 +223,7 @@
             <mappings>
               <mapping>
                 <directory>/usr/sbin</directory>
+                <documentation>false</documentation>
                 <filemode>755</filemode>
                 <directoryIncluded>false</directoryIncluded>
                 <sources>
@@ -240,6 +241,7 @@
               </mapping>
               <mapping>
                 <directory>/usr/lib</directory>
+                <documentation>false</documentation>
                 <directoryIncluded>false</directoryIncluded>
                 <sources>
                   <source>


### PR DESCRIPTION
Explicitly mark them as such otherwise they get marked with `%doc` in some build environments.