### PR TITLE
Add capability to set rescue mode bootloader filename

### DIFF
--- a/aii-core/src/main/perl/Shellfe.pm
+++ b/aii-core/src/main/perl/Shellfe.pm
@@ -580,6 +580,22 @@ sub run_plugin
                 $plug->set_active_config($st->{configuration});
             }
 
+	    my @params;
+	    if ($modulename eq "dhcp") {
+		if ($self->option("rescue") && $method eq CONFIGURE){
+		    $self->debug (4, "Setting params for DHCP plugin and rescue mode");
+		    @params = ($st->{configuration}, "rescue");
+		}
+		else {
+		    $self->debug (4, "Setting params for DHCP plugin and non-rescue mode");
+		    @params = ($st->{configuration}, "none");
+		}
+	    }
+	    else {
+		$self->debug (4, "Setting generic params");
+		@params = ($st->{configuration});
+	    }
+
             # The plugin method has to return success
             my $res = eval { $plug->$method ($st->{configuration}) };
             if ($@) {

--- a/aii-dhcp/src/main/perl/dhcp.pm
+++ b/aii-dhcp/src/main/perl/dhcp.pm
@@ -340,10 +340,16 @@ sub Configure
     if ($opts->{tftpserver}) {
         $tftpserver = $opts->{tftpserver};
     }
+
     if ($opts->{filename}) {
         $filename = $opts->{filename};
         $filename =~ s/BOOTSRVIP/$server_ip/;
     }
+
+    if ($opts->{rescue}) {
+        $filename = $opts->{rescue};
+    }
+
     if ($opts->{options}) {
         foreach my $k (sort keys %{$opts->{options}}) {
             $additional .= "option $k $opts->{options}->{$k};\n";


### PR DESCRIPTION
This commit adds the feature to aii-dhcp plugin to fetch bootloader filename for DHCP config to be included. Also handles situation if default bootloader may differ from the one would be used in case of rescue mode.

Resolves #343.