### PR TITLE
aii/ks: support for sending mail in el9 using correct s-nail format

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -1079,6 +1079,9 @@ sub kspostreboot_header
 
     my $mailx_smtp = "";
     $mailx_smtp .= " smtp=$tree->{mail}->{smtp}" if $tree->{mail}->{smtp};
+    # support for s-nail on el9
+    my $snail_smtp = "";
+    $snail_smtp .= "  -Smta=smtp://$tree->{mail}->{smtp}" if $tree->{mail}->{smtp};
 
     print <<EOF;
 #!/bin/bash
@@ -1099,7 +1102,11 @@ fail() {
     echo "Quattor installation on $fqdn failed: \\\$1"
     subject="[\\`date +'%x %R %z'\\`] Quattor installation on $fqdn failed: \\\$1"
     if [ -x /usr/bin/mailx ]; then
-        env MAILRC=/dev/null from=root\@$fqdn $mailx_smtp mailx -s "\\\$subject" $rootmail <<End_of_mailx
+        mailx_options="from=root\@$fqdn $mailx_smtp mailx"
+        if [ -x /usr/bin/s-nail ]; then
+            mailx_options="mailx -:/ -Sfrom=root\@$fqdn $snail_smtp"
+        fi
+        env MAILRC=/dev/null \\\$mailx_options -s "\\\$subject" $rootmail <<End_of_mailx
 
 \\`cat $logfile\\`
 ------------------------------------------------------------
@@ -1132,7 +1139,11 @@ success() {
 
     subject="[\\`date +'%x %R %z'\\`] Quattor installation on $fqdn succeeded"
     if [ -x /usr/bin/mailx ]; then
-        env MAILRC=/dev/null from=root\@$fqdn $mailx_smtp mailx -s "\\\$subject" $rootmail <<End_of_mailx
+        mailx_options="from=root\@$fqdn $mailx_smtp mailx"
+        if [ -x /usr/bin/s-nail ]; then
+            mailx_options="mailx -:/ -Sfrom=root\@$fqdn $snail_smtp"
+        fi
+        env MAILRC=/dev/null \\\$mailx_options -s "\\\$subject" $rootmail <<End_of_mailx
 
 Node $fqdn successfully installed.
 

--- a/aii-ks/src/test/perl/kickstart_postreboot.t
+++ b/aii-ks/src/test/perl/kickstart_postreboot.t
@@ -46,7 +46,11 @@ fail() {
     echo "Quattor installation on x.y failed: \$1"
     subject="[\`date +'%x %R %z'\`] Quattor installation on x.y failed: \$1"
     if [ -x /usr/bin/mailx ]; then
-        env MAILRC=/dev/null from=root@x.y  smtp=smtp.example.com mailx -s "\$subject" root@example.com <<End_of_mailx
+        mailx_options="from=root@x.y  smtp=smtp.example.com mailx"
+        if [ -x /usr/bin/s-nail ]; then
+            mailx_options="mailx -:/ -Sfrom=root@x.y   -Smta=smtp://smtp.example.com"
+        fi
+        env MAILRC=/dev/null \$mailx_options -s "\$subject" root@example.com <<End_of_mailx
 
 \`cat /root/ks-post-reboot.log\`
 ------------------------------------------------------------
@@ -80,7 +84,11 @@ success() {
 
     subject="[\`date +'%x %R %z'\`] Quattor installation on x.y succeeded"
     if [ -x /usr/bin/mailx ]; then
-        env MAILRC=/dev/null from=root@x.y  smtp=smtp.example.com mailx -s "\$subject" root@example.com <<End_of_mailx
+        mailx_options="from=root@x.y  smtp=smtp.example.com mailx"
+        if [ -x /usr/bin/s-nail ]; then
+            mailx_options="mailx -:/ -Sfrom=root@x.y   -Smta=smtp://smtp.example.com"
+        fi
+        env MAILRC=/dev/null \$mailx_options -s "\$subject" root@example.com <<End_of_mailx
 
 Node x.y successfully installed.
 


### PR DESCRIPTION
Current mailx options used in aii doesn't seem to send mail when s-nail is used, provide correct options when s-nail binary exists.

Fixes #342 