### PR TITLE
/var/tmp is supposed to be reboot persistent

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -996,7 +996,7 @@ sub ksinstall_rpm
 
     my $packager = $version >= ANACONDA_VERSION_EL_8_0 ? "dnf" : "yum";
     print join("\\\n    ",
-               "$packager -c /tmp/aii/yum/yum.conf -y install",
+               "$packager -c /var/tmp/aii/yum/yum.conf -y install",
                (map {s/^-//; "-x '$_'"} grep {$_ =~ /^-/} @pkgs),
                (grep {$_ !~ /^-/} @pkgs)
         ), " || fail 'Unable to install packages'\n";
@@ -1542,10 +1542,11 @@ sub yum_setup
     }
 
     print <<EOF;
-mkdir -p /tmp/aii/yum/repos
-chmod 700 /tmp/aii
+mkdir -p /var/tmp/aii/yum/repos
+chmod 700 /var/tmp/aii
+ln -s /var/tmp/aii /tmp/aii
 
-cat <<end_of_yum_conf > /tmp/aii/yum/yum.conf
+cat <<end_of_yum_conf > /var/tmp/aii/yum/yum.conf
 [main]
 EOF
 
@@ -1559,7 +1560,7 @@ EOF
         plugins => 1,
         installonly_limit => 3,
         clean_dependencies_on_remove => 1,
-        reposdir => '/tmp/aii/yum/repos',
+        reposdir => '/var/tmp/aii/yum/repos',
         obsoletes => $obsoletes,
     };
 
@@ -1574,7 +1575,7 @@ EOF
     print <<EOF;
 end_of_yum_conf
 
-cat <<end_of_repos > /tmp/aii/yum/repos/aii.repo
+cat <<end_of_repos > /var/tmp/aii/yum/repos/aii.repo
 EOF
 
     $self->debug(5, "Adding YUM repositories...");

--- a/aii-ks/src/test/resources/regexps/kickstart_yum_setup
+++ b/aii-ks/src/test/resources/regexps/kickstart_yum_setup
@@ -1,8 +1,8 @@
 Test the yum_setup
 ---
 ---
-^mkdir -p /tmp/aii/yum/repos$
-^cat <<end_of_yum_conf > /tmp/aii/yum/yum.conf$
+^mkdir -p /var/tmp/aii/yum/repos$
+^cat <<end_of_yum_conf > /var/tmp/aii/yum/yum.conf$
 ^\[main\]$
 ^cachedir=/var/cache/yum/\\\$basearch/\\\$releasever$
 ^clean_dependencies_on_remove=1$
@@ -15,10 +15,10 @@ Test the yum_setup
 ^logfile=/var/log/yum.log$
 ^obsoletes=0$
 ^plugins=1$
-^reposdir=/tmp/aii/yum/repos$
+^reposdir=/var/tmp/aii/yum/repos$
 ^retries=40$
 ^end_of_yum_conf$
-^cat <<end_of_repos > /tmp/aii/yum/repos/aii.repo$
+^cat <<end_of_repos > /var/tmp/aii/yum/repos/aii.repo$
 ^\[repo0\]$
 ^name=repo0$
 ^baseurl=http://www.example.com$


### PR DESCRIPTION
Looks like on e.g. EL9, /tmp is tmpfs during postinstall (if no dedicated partition is used for /tmp in the filesystem layout ofcourse)