### PR TITLE
Define default installation boot protocol as static

### DIFF
--- a/aii-ks/src/main/pan/quattor/aii/ks/config.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/config.pan
@@ -301,11 +301,13 @@ variable AII_OSINSTALL_BOOTDISK_ORDER ?= AII_OSINSTALL_DISKS['boot_order'];
 variable AII_OSINSTALL_DISABLE_SERVICE ?= null;
 "disable_service" ?= AII_OSINSTALL_DISABLE_SERVICE;
 
-
-#
-# How will we configure the network during the installation?
-# Default to 'dhcp'
-variable  AII_OSINSTALL_BOOTPROTO ?= 'dhcp';
+@{
+desc = default boot protocol for installation
+values = choice between 'dhcp' or 'static' (see schema)
+default = static
+required = no
+}
+variable  AII_OSINSTALL_BOOTPROTO ?= 'static';
 "bootproto" ?= AII_OSINSTALL_BOOTPROTO;
 
 #

--- a/aii-ks/src/main/pan/quattor/aii/ks/variants/el7.pan
+++ b/aii-ks/src/main/pan/quattor/aii/ks/variants/el7.pan
@@ -15,7 +15,6 @@ prefix "/system/aii/osinstall/ks";
 
 # el7
 "version" = "19.31";
-"bootproto" = "static";
 "enable_sshd" = true;
 "cmdline" = true;
 


### PR DESCRIPTION
- Used to be the case in EL7 but defined in the EL7 variant and lost afterwards