### PR TITLE
aii-ks: Only wait for 120 seconds in wait_for_network

### DIFF
--- a/aii-ks/src/main/perl/ks.pm
+++ b/aii-ks/src/main/perl/ks.pm
@@ -1165,16 +1165,7 @@ End_of_sendmail
 # Wait for functional network up by testing DNS lookup via nslookup.
 wait_for_network () {
     # Wait up to 2 minutes until the network comes up
-    i=0
-    while ! nslookup \\\$1 > /dev/null
-    do
-        sleep 1
-        let i=\\\$i+1
-        if [ \\\$i -gt 120 ]
-        then
-            fail "Network does not come up (nslookup \\\$1)"
-        fi
-    done
+    nslookup -retry=12 -timeout=10 \\\$1 > /dev/null || fail "Network does not come up (nslookup \\\$1)"
 }
 
 # Ensure that the log file doesn't exist.

--- a/aii-ks/src/test/perl/kickstart_postreboot.t
+++ b/aii-ks/src/test/perl/kickstart_postreboot.t
@@ -110,16 +110,7 @@ End_of_sendmail
 # Wait for functional network up by testing DNS lookup via nslookup.
 wait_for_network () {
     # Wait up to 2 minutes until the network comes up
-    i=0
-    while ! nslookup \$1 > /dev/null
-    do
-        sleep 1
-        let i=\$i+1
-        if [ \$i -gt 120 ]
-        then
-            fail "Network does not come up (nslookup \$1)"
-        fi
-    done
+    nslookup -retry=12 -timeout=10 \$1 > /dev/null || fail "Network does not come up (nslookup \$1)"
 }
 
 # Ensure that the log file doesn't exist.


### PR DESCRIPTION
The previous code assumed that `nslookup` failed instantly, however the default behaviour makes three requests, each with a timeout of 5 seconds, so a host with completely broken networking will take `120 * (15 + 1)` seconds (32 minutes) to error out.

Fixes #354.